### PR TITLE
Add a line break after a single-line trailing comment.

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1133,10 +1133,10 @@
             if (stmt.trailingComments) {
                 for (i = 0, len = stmt.trailingComments.length; i < len; i += 1) {
                     comment = stmt.trailingComments[i];
+                    result += addIndent(generateComment(comment));
                     if (!endsWithLineTerminator(result)) {
                         result += '\n';
                     }
-                    result += addIndent(generateComment(comment));
                 }
             }
         }


### PR DESCRIPTION
Hello

I found that escodegen wasn't correctly adding a line break after all comment types.  It's just trying to add it a little early.
Here's a tweak to make it work.

Cheers
K
