### PR TITLE
Add JSON and concise representation of numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Emacs
+*~
+\#*\#
+
+# Node modules
+node_modules/
+
+# Cover
+.coverage_data/
+cover_html/

--- a/test/options.js
+++ b/test/options.js
@@ -1,4 +1,5 @@
 /*
+  Copyright (C) 2012 Robert Gust-Bardon <donate@robert.gust-bardon.org>
   Copyright (C) 2012 Yusuke Suzuki <utatane.tea@gmail.com>
 
   Redistribution and use in source and binary forms, with or without
@@ -27,34 +28,266 @@
 
 var data = [{
     options: {
-        format: {
-            base: 2,
-            indent: '    '
-        }
+        base: 2,
+        indent: '    '
     },
-    items : {
-        '        test': 'test'
+    items: {
+        'test': '        test;'
     }
 }, {
     options: {
-        format: {
-            base: 4,
-            indent: '\t'
-        }
+        base: 4,
+        indent: '\t'
     },
-    items : {
-        '\t\t\t\ttest': 'test'
+    items: {
+        'test': '\t\t\t\ttest;'
     }
 }, {
     options: {
         base: '  ',
         format: {
-            base: 4,
-            indent: '\t'
+            indent: {
+                style: {
+                    base: 4,
+                    indent: '\t'
+                }
+            }
         }
     },
-    items : {
-        '  test': 'test'
+    items: {
+        'test': '  test;'
+    }
+}, {
+    options: {
+        format: {
+            json: false,
+            renumber: false,
+            hexadecimal: false
+        },
+        parse: true
+    },
+    items: {
+        '42e-010': '42e-010;'
+    }
+}, {
+    options: {
+        format: {
+            json: true,
+            renumber: false,
+            hexadecimal: false
+        },
+        parse: true
+    },
+    items: {
+        '42e-010': '4.2e-9;'
+    }
+}, {
+    options: {
+        format: {
+            json: false,
+            renumber: true,
+            hexadecimal: false
+        },
+        parse: true
+    },
+    items: {
+        '42e-010': '42e-010;'
+    }
+}, {
+    options: {
+        format: {
+            json: false,
+            renumber: false,
+            hexadecimal: false
+        },
+        parse: null
+    },
+    items: {
+        '4.2e+500': '1e+400;',
+        '1.7976931348623157e+308': '1.7976931348623157e+308;',
+        '4.2e+100': '4.2e+100;',
+        '1000000000001': '1000000000001;',
+        '100000000001': '100000000001;',
+        '42000': '42000;',
+        '4200': '4200;',
+        '420': '420;',
+        '42': '42;',
+        '4.2': '4.2;',
+        '0': '0;',
+        '0.42': '0.42;',
+        '0.042': '0.042;',
+        '0.0042': '0.0042;',
+        '0.00042': '0.00042;',
+        '4.2e-99': '4.2e-99;',
+        '5e-324': '5e-324;'
+    }
+}, {
+    options: {
+        format: {
+            json: true,
+            renumber: false,
+            hexadecimal: false
+        },
+        parse: null
+    },
+    items: {
+        '4.2e+500': 'null;',
+        '1.7976931348623157e+308': '1.7976931348623157e+308;',
+        '4.2e+100': '4.2e+100;',
+        '1000000000001': '1000000000001;',
+        '100000000001': '100000000001;',
+        '42000': '42000;',
+        '4200': '4200;',
+        '420': '420;',
+        '42': '42;',
+        '4.2': '4.2;',
+        '0': '0;',
+        '0.42': '0.42;',
+        '0.042': '0.042;',
+        '0.0042': '0.0042;',
+        '0.00042': '0.00042;',
+        '4.2e-99': '4.2e-99;',
+        '5e-324': '5e-324;'
+    }
+}, {
+    options: {
+        format: {
+            json: true,
+            renumber: true,
+            hexadecimal: false
+        },
+        parse: null
+    },
+    items: {
+        '4.2e+500': 'null;',
+        '1.7976931348623157e+308': '1.7976931348623157e308;',
+        '4.2e+100': '42e99;',
+        '1000000000001': '1000000000001;',
+        '100000000001': '100000000001;',
+        '42000': '42e3;',
+        '4200': '4200;',
+        '420': '420;',
+        '42': '42;',
+        '4.2': '4.2;',
+        '0': '0;',
+        '0.42': '0.42;',
+        '0.042': '0.042;',
+        '0.0042': '42e-4;',
+        '0.00042': '42e-5;',
+        '4.2e-99': '4.2e-99;',
+        '5e-324': '5e-324;'
+    }
+}, {
+    options: {
+        format: {
+            json: true,
+            renumber: true,
+            hexadecimal: true
+        },
+        parse: null
+    },
+    items: {
+        '4.2e+500': 'null;',
+        '1.7976931348623157e+308': '1.7976931348623157e308;',
+        '4.2e+100': '42e99;',
+        '1000000000001': '1000000000001;',
+        '100000000001': '100000000001;',
+        '42000': '42e3;',
+        '4200': '4200;',
+        '420': '420;',
+        '42': '42;',
+        '4.2': '4.2;',
+        '0': '0;',
+        '0.42': '0.42;',
+        '0.042': '0.042;',
+        '0.0042': '42e-4;',
+        '0.00042': '42e-5;',
+        '4.2e-99': '4.2e-99;',
+        '5e-324': '5e-324;'
+    }
+}, {
+    options: {
+        format: {
+            json: false,
+            renumber: true,
+            hexadecimal: false
+        },
+        parse: null
+    },
+    items: {
+        '4.2e+500': '1e400;',
+        '1.7976931348623157e+308': '1.7976931348623157e308;',
+        '4.2e+100': '42e99;',
+        '1000000000001': '1000000000001;',
+        '100000000001': '100000000001;',
+        '42000': '42e3;',
+        '4200': '4200;',
+        '420': '420;',
+        '42': '42;',
+        '4.2': '4.2;',
+        '0': '0;',
+        '0.42': '.42;',
+        '0.042': '.042;',
+        '0.0042': '.0042;',
+        '0.00042': '42e-5;',
+        '4.2e-99': '4.2e-99;',
+        '5e-324': '5e-324;'
+    }
+}, {
+    options: {
+        format: {
+            json: false,
+            renumber: true,
+            hexadecimal: true
+        },
+        parse: null
+    },
+    items: {
+        '4.2e+500': '1e400;',
+        '1.7976931348623157e+308': '1.7976931348623157e308;',
+        '4.2e+100': '42e99;',
+        '1000000000001': '0xe8d4a51001;',
+        '100000000001': '100000000001;',
+        '42000': '42e3;',
+        '4200': '4200;',
+        '420': '420;',
+        '42': '42;',
+        '4.2': '4.2;',
+        '0': '0;',
+        '0.42': '.42;',
+        '0.042': '.042;',
+        '0.0042': '.0042;',
+        '0.00042': '42e-5;',
+        '4.2e-99': '4.2e-99;',
+        '5e-324': '5e-324;'
+    }
+}, {
+    options: {
+        format: {
+            json: false,
+            renumber: false,
+            hexadecimal: true
+        },
+        parse: null
+    },
+    items: {
+        '4.2e+500': '1e+400;',
+        '1.7976931348623157e+308': '1.7976931348623157e+308;',
+        '4.2e+100': '4.2e+100;',
+        '1000000000001': '1000000000001;',
+        '100000000001': '100000000001;',
+        '42000': '42000;',
+        '4200': '4200;',
+        '420': '420;',
+        '42': '42;',
+        '4.2': '4.2;',
+        '0': '0;',
+        '0.42': '0.42;',
+        '0.042': '0.042;',
+        '0.0042': '0.0042;',
+        '0.00042': '0.00042;',
+        '4.2e-99': '4.2e-99;',
+        '5e-324': '5e-324;'
     }
 }];
 
@@ -87,28 +320,35 @@ var data = [{
     }
     NotMatchingError.prototype = new Error();
 
-    function runTest(options, source, expected) {
-        var tree, actual;
+    function runTest(options, source, expectedCode) {
+        var tree, actualTree, expectedTree, actualCode;
         try {
-            tree = esprima.parse(source, options);
-            expected = JSON.stringify(tree, adjustRegexLiteral, 4);
-            tree = esprima.parse(escodegen.generate(tree), options);
-            actual = JSON.stringify(tree, adjustRegexLiteral, 4);
+            tree = esprima.parse(source);
+            expectedTree = JSON.stringify(tree, adjustRegexLiteral, 4);
+            actualCode = escodegen.generate(esprima.parse(source, {raw: true}), options);
+            tree = esprima.parse(actualCode);
+            actualTree = JSON.stringify(tree, adjustRegexLiteral, 4);
         } catch (e) {
-            throw new NotMatchingError(expected, e.toString());
+            throw new NotMatchingError(expectedCode, e.toString());
         }
-        if (expected !== actual) {
-            throw new NotMatchingError(expected, actual);
+        if (expectedTree !== actualTree) {
+            throw new NotMatchingError(expectedTree, actualTree);
+        }
+        if (expectedCode !== actualCode) {
+            throw new NotMatchingError(expectedCode, actualCode);
         }
     }
 
     data.forEach(function (category) {
         var options = category.options;
         Object.keys(category.items).forEach(function (source) {
-            var expected = category.items[source];
+            var expectedCode = category.items[source];
             total += 1;
+            if (options.parse) {
+                options.parse = esprima.parse;
+            }
             try {
-                runTest(options, source, expected);
+                runTest(options, source, expectedCode);
             } catch (e) {
                 e.source = source;
                 failures.push(e);


### PR DESCRIPTION
Introduces options.format.json, options.format.renumber, and
options.format.hexadecimal.

As yet, options.format.json does not affect string literals.

options.format.json takes precedence over options.parse and disallows
options.format.hexadecimal.

options.format.hexadecimal requires options.format.renumber.

Added .gitignore for Emacs and Cover.

options.format.json represents positive infinity using the null literal as in
JSON.stringify(1e400)

options.format.json and options.format.reduce result in 4.2e+100
becoming 42e99, 42000 becoming 42e3, and 0.0042 becoming 42e-4.

Without options.format.json, options.format.reduce additionally
results in 0.0042 becoming .0042.

With options.format.hexadecimal, 1000000000001 becomes 0xe8d4a51001.

Swapped keys with values for the items key of the elements of data in
test/options.js

Put options.format.base and options.format.indent in
options.format.indent.style in test/options.js

Fixed expected being overwritten in runTest in test/options.js
