### PR TITLE
Add the ability to remove superfluous white space

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1000,8 +1000,8 @@
                 allowCall: true
             });
             // 12.4 '{', 'function' is not allowed in this position.
-            // wrap espression with parentheses
-            if (result[0] === '{' || result.indexOf('function ') === 0) {
+            // wrap expression with parentheses
+            if (result.charAt(0) === '{' || result.slice(0, 8) === 'function' && " (".indexOf(result.charAt(8)) >= 0) {
                 result = '(' + result + ');';
             } else {
                 result += ';';

--- a/test/options.js
+++ b/test/options.js
@@ -297,7 +297,7 @@ var data = [{
         parse: null
     },
     items: {
-        '+\'\'' : '+\'\';',
+        '+\'\'': '+\'\';',
         '+""': '+\'\';',
         '+\'\\\'\'': '+\'\\\'\';',
         '+\'"\'': '+\'"\';',
@@ -334,7 +334,7 @@ var data = [{
         parse: null
     },
     items: {
-        '+\'\'' : '+"";',
+        '+\'\'': '+"";',
         '+""': '+"";',
         '+\'\\\'\'': '+"\'";',
         '+\'"\'': '+"\\"";',
@@ -371,7 +371,7 @@ var data = [{
         parse: null
     },
     items: {
-        '+\'\'' : '+"";',
+        '+\'\'': '+"";',
         '+""': '+"";',
         '+\'\\\'\'': '+"\'";',
         '+\'"\'': '+"\\"";',
@@ -408,7 +408,7 @@ var data = [{
         parse: null
     },
     items: {
-        '+\'\'' : '+\'\';',
+        '+\'\'': '+\'\';',
         '+""': '+\'\';',
         '+\'\\\'\'': '+"\'";',
         '+\'"\'': '+\'"\';',
@@ -445,7 +445,7 @@ var data = [{
         parse: null
     },
     items: {
-        '+\'\'' : '+\'\';',
+        '+\'\'': '+\'\';',
         '+""': '+\'\';',
         '+\'\\\'\'': '+\'\\\'\';',
         '+\'"\'': '+\'"\';',
@@ -482,7 +482,7 @@ var data = [{
         parse: true
     },
     items: {
-        '+\'\'' : '+\'\';',
+        '+\'\'': '+\'\';',
         '+""': '+"";',
         '+\'\\\'\'': '+\'\\\'\';',
         '+\'"\'': '+\'"\';',
@@ -531,7 +531,7 @@ var data = [{
         parse: true
     },
     items: {
-        '+""' : '+"";',
+        '+""': '+"";',
         '+\'\\0\'': '+\'\\0\';'
     }
 }, {
@@ -587,9 +587,12 @@ var data = [{
         '!{get 42(){},set 42(bar){}}': '  !{\n    get 42() {\n    },\n    set 42(bar) {\n    }\n  };',
         'foo:while(42)break foo;': '  foo:\n    while (42)\n      break foo;',
         'foo:while(42)continue foo;': '  foo:\n    while (42)\n      continue foo;',
-        'var foo' : '  var foo;',
+        'var foo': '  var foo;',
         'for(var foo in 42);': '  for (var foo in 42);',
-        'function foo(){}': '  function foo() {\n  }'
+        'function foo(){}': '  function foo() {\n  }',
+
+        '({})': '  ({});',
+        '(function(){})': '  (function () {\n  });'
     }
 }, {
     options: {
@@ -644,9 +647,12 @@ var data = [{
         '!{get 42(){},set 42(bar){}}': '!{get 42(){},set 42(bar){}};',
         'foo:while(42)break foo;': 'foo:while(42)break foo;',
         'foo:while(42)continue foo;': 'foo:while(42)continue foo;',
-        'var foo' : 'var foo;',
+        'var foo': 'var foo;',
         'for(var foo in 42);': 'for(var foo in 42);',
-        'function foo(){}': 'function foo(){}'
+        'function foo(){}': 'function foo(){}',
+
+        '({})': '({});',
+        '(function(){})': '(function(){});'
     }
 }];
 


### PR DESCRIPTION
Introduces options.format.compact which takes precedence over
options.base, options.indent, and options.format.indent.

Untested with comments.

Simplifies isWhiteSpace.

Removes unicodeEscape as it is not used anymore.
