### PR TITLE
Add the ability to omit superfluous parentheses

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -705,7 +705,7 @@
             );
 
             len = expr['arguments'].length;
-            if (parentheses || len > 0) {
+            if (parentheses || len > 0 || precedence === Precedence.Call) {
                 result += '(';
                 for (i = 0; i < len; i += 1) {
                     result += generateExpression(expr['arguments'][i], {

--- a/test/options.js
+++ b/test/options.js
@@ -663,8 +663,15 @@ var data = [{
         }
     },
     items: {
+        'new Foo()': 'new Foo();',
         'new Foo(42)': 'new Foo(42);',
-        'new Foo() in bar': 'new Foo() in bar;'
+        'new Foo() in bar': 'new Foo() in bar;',
+        'new Date.constructor()': 'new Date.constructor();',
+        'new Date().constructor': 'new Date().constructor;',
+        'new Date.setUTCMilliseconds(0)': 'new Date.setUTCMilliseconds(0);',
+        'new Date().setUTCMilliseconds(0)': 'new Date().setUTCMilliseconds(0);',
+        'new new Foo()()': 'new new Foo()();',
+        'new new (Foo()())()()': 'new new (Foo()())()();'
     }
 }, {
     options: {
@@ -673,8 +680,15 @@ var data = [{
         }
     },
     items: {
+        'new Foo()': 'new Foo;',
         'new Foo(42)': 'new Foo(42);',
-        'new Foo() in bar': 'new Foo in bar;'
+        'new Foo() in bar': 'new Foo in bar;',
+        'new Date.constructor()': 'new Date.constructor;',
+        'new Date().constructor': 'new Date().constructor;',
+        'new Date.setUTCMilliseconds(0)': 'new Date.setUTCMilliseconds(0);',
+        'new Date().setUTCMilliseconds(0)': 'new Date().setUTCMilliseconds(0);',
+        'new new Foo()': 'new new Foo;',
+        'new new (Foo()())()()': 'new new (Foo()());'
     }
 }];
 


### PR DESCRIPTION
Introduces options.format.parentheses.

Affects new expressions without arguments.
