### PR TITLE
Fix missing semicolon in non-final SwitchCase

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1225,7 +1225,7 @@
             }
 
             for (; i < len; i += 1) {
-                fragment = addIndent(generateStatement(stmt.consequent[i], {semicolonOptional: i === len - 1}));
+                fragment = addIndent(generateStatement(stmt.consequent[i], {semicolonOptional: i === len - 1 && semicolon === ''}));
                 result += fragment;
                 if (i + 1 !== len && !endsWithLineTerminator(fragment)) {
                     result += newline;

--- a/test/options.js
+++ b/test/options.js
@@ -780,6 +780,16 @@ var data = [{
         '42': '  42',
         '42;foo': '  42;\n  foo'
     }
+}, {
+    options: {
+        format: {
+            compact: true,
+            semicolons: false
+        }
+    },
+    items: {
+        'switch(42){case 42:42;default:}': 'switch(42){case 42:42;default:}'
+    }
 }];
 
 (function () {


### PR DESCRIPTION
With options.format.compact and without options.format.semicolons,

switch(42){case 42:42;default:}

resulted in

switch(42){case 42:42default:}
