### PR TITLE
escodegen: Don't crash when we have an empty array of leadingComments

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -525,7 +525,7 @@
     function addCommentsToStatement(stmt, result) {
         var i, len, comment, save, node, tailingToStatement, specialBase, fragment;
 
-        if (stmt.leadingComments) {
+        if (stmt.leadingComments && stmt.leadingComments.length > 0) {
             save = result;
 
             comment = stmt.leadingComments[0];


### PR DESCRIPTION
See patch. Right now doing something like:

```
var node = { type: ...,
             leadingComments: [] };
escodegen.generate(node, { comments: true });
```

will fail.
