### PR TITLE
function declarations must be named

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1372,11 +1372,7 @@
             break;
 
         case Syntax.FunctionDeclaration:
-            result = 'function' + space;
-            if (stmt.id) {
-                result += (space === '' ? ' ' : '') + stmt.id.name;
-            }
-            result += generateFunctionBody(stmt);
+            result = 'function ' + stmt.id.name + generateFunctionBody(stmt);
             break;
 
         case Syntax.ReturnStatement:


### PR DESCRIPTION
This logic was unnecessary, since function declarations must have a name. See [ES5 §13](http://es5.github.com/#x13).
