### PR TITLE
Compact missing a space in do...while

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1060,7 +1060,7 @@
             break;
 
         case Syntax.DoWhileStatement:
-            result = 'do' + maybeBlock(stmt.body);
+            result = join('do', maybeBlock(stmt.body));
             result += maybeBlockSuffix(stmt.body, result);
             result += 'while' + space + '(' + generateExpression(stmt.test, {
                 precedence: Precedence.Sequence,


### PR DESCRIPTION
If we have a DoWhileStatement with a single epxression rather than a BlockStatement in the body, format: {compact: true} erroneously leaves out a space between the do and start of the body statement.

Test case:

``` javascript
var ec = require('../escodegen/escodegen.js');

var node = {
  type: "Program",
  body: [
    {
      type: "DoWhileStatement",
      body: {
        type: "ExpressionStatement",
        expression: {
          type: "CallExpression",
          callee: {
            type: "MemberExpression",
            object: {
              type: "Identifier",
              name: "console"
            },
            property: {
              type: "Identifier",
              name: "log"
            },
            computed: false
          },
          arguments: [
            {
              type: "Literal",
              value: "hi"
            }
          ]
        }
      },
      test: {
        type: "Literal",
        value: 0
      }
    }
  ]
};

console.log(ec.generate(node, {format: {compact: true}}));
```

outputs:
`doconsole.log('hi'); while(0);`

I'll go ahead and try to patch this, if that's alright.
