### PR TITLE
Use an array for ReturnStatement with no args.

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1531,7 +1531,7 @@
                     })
                 ), semicolon];
             } else {
-                result = 'return' + semicolon;
+                result = ['return' + semicolon];
             }
             break;
 


### PR DESCRIPTION
Correctly return an array not a string for a return statement with no args.

Fixes generation of:

```
return; //comment'
```
