### PR TITLE
Multiple source files per sourcemap

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -557,7 +557,7 @@
         if (node.loc == null) {
             return new SourceNode(null, null, sourceMap, generated);
         }
-        return new SourceNode(node.loc.start.line, node.loc.start.column, sourceMap, generated);
+        return new SourceNode(node.loc.start.line, node.loc.start.column, (sourceMap === true ? node.loc.source || null : sourceMap), generated);
     }
 
     function adjustMultilineComment(value, specialBase) {


### PR DESCRIPTION
This adds support for multiple sources in the source map output.

In what I believe is a backwards-compatible change, setting `options.sourceMap` to `true` causes the generated source map to use `loc.source` for the source file (conforming to the Parser APi spec for `SourceLocation`).
