### PR TITLE
Support ES6 / harmony yield, with '*' (controversial)

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -117,7 +117,9 @@
         VariableDeclaration: 'VariableDeclaration',
         VariableDeclarator: 'VariableDeclarator',
         WhileStatement: 'WhileStatement',
-        WithStatement: 'WithStatement'
+        WithStatement: 'WithStatement',
+        YieldExpression: 'YieldExpression',
+
     };
 
     Precedence = {
@@ -991,6 +993,21 @@
             result = parenthesize(result, Precedence.Unary, precedence);
             break;
 
+        case Syntax.YieldExpression:  // nearly same as Return
+            if (expr.argument) {
+                result = [join(
+                    'yield',
+                    generateExpression(expr.argument, {
+                        precedence: Precedence.Sequence,
+                        allowIn: true,
+                        allowCall: true
+                    })
+                )];
+            } else {
+                result = 'yield';
+            }
+            break;
+
         case Syntax.UpdateExpression:
             if (expr.prefix) {
                 result = parenthesize(
@@ -1543,7 +1560,7 @@
             break;
 
         case Syntax.FunctionDeclaration:
-            result = ['function ' + stmt.id.name, generateFunctionBody(stmt)];
+            result = [( stmt.generator ? 'function* ':'function ' ) + stmt.id.name, generateFunctionBody(stmt)];
             break;
 
         case Syntax.ReturnStatement:
@@ -1712,6 +1729,8 @@
         case Syntax.ThisExpression:
         case Syntax.UnaryExpression:
         case Syntax.UpdateExpression:
+        case Syntax.YieldExpression:
+
             result = generateExpression(node, {
                 precedence: Precedence.Sequence,
                 allowIn: true,
@@ -1778,7 +1797,9 @@
         VariableDeclaration: ['declarations'],
         VariableDeclarator: ['id', 'init'],
         WhileStatement: ['test', 'body'],
-        WithStatement: ['object', 'body']
+        WithStatement: ['object', 'body'],
+        YieldExpression: ['argument'],
+
     };
 
     VisitorOption = {

--- a/test/test.js
+++ b/test/test.js
@@ -14698,6 +14698,77 @@ data = {
             },
             tokens: []
         }
+
+    },
+
+    'Yield (with star, harmony proposed)': {
+        'function* a() {\n    yield 1;\n}': {
+            generateFrom:           {
+                type: 'Program',
+                body: [{
+                    type: 'FunctionDeclaration',
+                    id: {
+                        type: 'Identifier',
+                        name: 'a',
+                        range: [10, 11],
+                        loc: {
+                            start: { line: 1, column: 10 },
+                            end: { line: 1, column: 11 }
+                        }
+                    },
+                    params: [],
+                    defaults: [],
+                    body: {
+                        type: 'BlockStatement',
+                        body: [{
+                            type: 'ExpressionStatement',
+                            expression: {
+                                type: 'YieldExpression',
+                                argument: {
+                                    type: 'Literal',
+                                    value: 1,
+                                    raw: '1',
+                                    range: [21, 22],
+                                    loc: {
+                                        start: { line: 1, column: 21 },
+                                        end: { line: 1, column: 22 }
+                                    }
+                                },
+                                delegate: false,
+                                range: [15, 22],
+                                loc: {
+                                    start: { line: 1, column: 15 },
+                                    end: { line: 1, column: 22 }
+                                }
+                            },
+                            range: [15, 22],
+                            loc: {
+                                start: { line: 1, column: 15 },
+                                end: { line: 1, column: 22 }
+                            }
+                        }],
+                        range: [14, 23],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 23 }
+                        }
+                    },
+                    rest: null,
+                    generator: true,
+                    expression: false,
+                    range: [0, 23],
+                    loc: {
+                        start: { line: 1, column: 0 },
+                        end: { line: 1, column: 23 }
+                    }
+                }],
+                range: [0, 23],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 23 }
+                }
+            }
+        }
     }
 };
 


### PR DESCRIPTION
Controversy:
- 'star' vs. 'starless' makes this incompatible with current Mozilla 1.7 JS.

Incomplete:
- delegation not indicated properly.
  (I was unable to generate a delegating example)
