### PR TITLE
Fixes #80 - Fix when ObjectExpression properties don't have the 'Property' type

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -806,17 +806,18 @@
     }
 
     function generateExpression(expr, option) {
-        var result, precedence, currentPrecedence, i, len, raw, fragment, multiline, leftChar, leftSource, rightChar, rightSource, allowIn, allowCall, allowUnparenthesizedNew, property, key, value;
+        var result, precedence, type, currentPrecedence, i, len, raw, fragment, multiline, leftChar, leftSource, rightChar, rightSource, allowIn, allowCall, allowUnparenthesizedNew, property, key, value;
 
         precedence = option.precedence;
         allowIn = option.allowIn;
         allowCall = option.allowCall;
+        type = expr.type || option.type;
 
         if (extra.verbatim && expr.hasOwnProperty(extra.verbatim)) {
             return generateVerbatim(expr, option);
         }
 
-        switch (expr.type) {
+        switch (type) {
         case Syntax.SequenceExpression:
             result = [];
             allowIn |= (Precedence.Sequence < precedence);
@@ -1188,7 +1189,8 @@
                 fragment = generateExpression(expr.properties[0], {
                     precedence: Precedence.Sequence,
                     allowIn: true,
-                    allowCall: true
+                    allowCall: true,
+                    type: Syntax.Property
                 });
             });
 
@@ -1216,7 +1218,8 @@
                         result.push(indent, generateExpression(expr.properties[i], {
                             precedence: Precedence.Sequence,
                             allowIn: true,
-                            allowCall: true
+                            allowCall: true,
+                            type: Syntax.Property
                         }));
                         if (i + 1 < len) {
                             result.push(',' + newline);

--- a/test/test.js
+++ b/test/test.js
@@ -845,6 +845,32 @@ data = {
             }
         },
 
+        'x = { answer: 4 }': {
+            type: 'ExpressionStatement',
+            expression: {
+                type: 'AssignmentExpression',
+                operator: '=',
+                left: {
+                    type: 'Identifier',
+                    name: 'x'
+                },
+                right: {
+                    type: 'ObjectExpression',
+                    properties: [{
+                        key: {
+                            type: 'Identifier',
+                            name: 'answer'
+                        },
+                        value: {
+                            type: 'Literal',
+                            value: 4
+                        },
+                        kind: 'init'
+                    }]
+                }
+            }
+        },
+
         'x = { answer: 42 }': {
             type: 'ExpressionStatement',
             expression: {


### PR DESCRIPTION
Fixes #80

By (ab)using the generateExpression option object, so the ObjectExpression case
sets the expression type for its properties, when those are not set. This
prevents breakage, because according to SpiderMonkey Parse API, the type field
is not really required.
