### PR TITLE
Add sourceMapRoot option, to set the sourceRoot option for sourcemaps.

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -207,6 +207,7 @@
                 parenthesizedComprehensionBlock: false
             },
             sourceMap: null,
+            sourceMapRoot: null,
             sourceMapWithCode: false,
             directive: false,
             verbatim: null
@@ -1958,7 +1959,10 @@
             return result.toString();
         }
 
-        pair = result.toStringWithSourceMap({file: options.sourceMap});
+        pair = result.toStringWithSourceMap({
+            file: options.sourceMap,
+            sourceRoot: options.sourceMapRoot
+        });
 
         if (options.sourceMapWithCode) {
             return pair;


### PR DESCRIPTION
From the mozilla/source-map docs:
    sourceRoot: An optional root for all relative URLs in this source map.
