### PR TITLE
Multi comments in object literals are lost

### DIFF
--- a/test/comment/object-literal-multi-comment.expected.js
+++ b/test/comment/object-literal-multi-comment.expected.js
@@ -1,0 +1,4 @@
+var a = {
+    /* comment */
+    b : 1
+};

--- a/test/comment/object-literal-multi-comment.js
+++ b/test/comment/object-literal-multi-comment.js
@@ -1,0 +1,4 @@
+var a = {
+    /* comment */
+    b : 1
+};


### PR DESCRIPTION
Not sure what expected should *actually* be since there's a bug, but the file I checked in is my best guess.

### Test output ###

```
: Expected
    var a = {
        /* comment one */
        b : 1
    };

to match
    var a = { b: 1 };
```