### PR TITLE
Add `sourceContent` option support.

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2083,14 +2083,21 @@
             return result.toString();
         }
 
+
         pair = result.toStringWithSourceMap({
             file: options.file,
             sourceRoot: options.sourceMapRoot
         });
 
+        if (options.sourceContent) {
+            pair.map.setSourceContent(options.sourceMap,
+                                      options.sourceContent);
+        }
+
         if (options.sourceMapWithCode) {
             return pair;
         }
+
         return pair.map.toString();
     }
 


### PR DESCRIPTION
In V3 spec of source-maps support for `sourceContent` was added. With this option original file source get's encoded in source-map itself. This is also an only option supported by browserify (any other output will loose
source mapping after browserification).

This change adds additional `sourceContent` option, if it's specified generated source-map will contain it.
