### PR TITLE
Support for multiple catch clauses (SpiderMonkey-specific)

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1457,7 +1457,7 @@
     }
 
     function generateStatement(stmt, option) {
-        var i, len, result, node, allowIn, functionBody, directiveContext, fragment, semicolon, guard;
+        var i, len, result, node, allowIn, functionBody, directiveContext, fragment, semicolon;
 
         allowIn = true;
         semicolon = ';';


### PR DESCRIPTION
Spidermonkey AST can contain multtiple catch clauses. This diff supports them.
Here's the sample js which fails on current escodegen@1.0.1 and runs successfully with this diff:

``` javascript
try {
  smth();
} catch (ex if ex instanceof TypeError) {
  console.log('TypeError');
} catch (ex if ex instanceof ReferenceError) {
  console.log('ReferenceError');
}
```
