### PR TITLE
Add star to GeneratorExpression

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1145,7 +1145,7 @@
             break;
 
         case Syntax.FunctionExpression:
-            result = 'function';
+            result = expr.generator && !extra.moz.starlessGenerator ? 'function*' : 'function';
 
             if (expr.id) {
                 result = [result, noEmptySpace(),

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -255,6 +255,103 @@ data = {
                     end: { line: 1, column: 23 }
                 }
             }
+        },
+
+        'var a = function* () {\n    yield 1;\n};': {
+            generateFrom: {
+                "type": "Program",
+                "body": [
+                    {
+                        "type": "VariableDeclaration",
+                        "declarations": [
+                            {
+                                "type": "VariableDeclarator",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "a"
+                                },
+                                "init": {
+                                    "type": "FunctionExpression",
+                                    "id": null,
+                                    "params": [],
+                                    "defaults": [],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "body": [
+                                            {
+                                                "type": "ExpressionStatement",
+                                                "expression": {
+                                                    "type": "YieldExpression",
+                                                    "argument": {
+                                                        "type": "Literal",
+                                                        "value": 1,
+                                                        "raw": "1"
+                                                    },
+                                                    "delegate": false
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "rest": null,
+                                    "generator": true,
+                                    "expression": false
+                                }
+                            }
+                        ],
+                        "kind": "var"
+                    }
+                ]
+            }
+        },
+
+        'var a = function* b() {\n    yield 1;\n};': {
+            generateFrom: {
+                "type": "Program",
+                "body": [
+                    {
+                        "type": "VariableDeclaration",
+                        "declarations": [
+                            {
+                                "type": "VariableDeclarator",
+                                "id": {
+                                    "type": "Identifier",
+                                    "name": "a"
+                                },
+                                "init": {
+                                    "type": "FunctionExpression",
+                                    "id": {
+                                        "type": "Identifier",
+                                        "name": "b"
+                                    },
+                                    "params": [],
+                                    "defaults": [],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "body": [
+                                            {
+                                                "type": "ExpressionStatement",
+                                                "expression": {
+                                                    "type": "YieldExpression",
+                                                    "argument": {
+                                                        "type": "Literal",
+                                                        "value": 1,
+                                                        "raw": "1"
+                                                    },
+                                                    "delegate": false
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "rest": null,
+                                    "generator": true,
+                                    "expression": false
+                                }
+                            }
+                        ],
+                        "kind": "var"
+                    }
+                ]
+            }
         }
     },
 


### PR DESCRIPTION
I use generator in sweet.js.

``` js
var a = function* () { yield 1; };

// output
// var a$254 = function () {
//     yield 1;
// };
```

The star disappear from FunctionExpression, but does not disappear from FunctionDeclaration.
I see specification of ES6, but not found this behavior.
https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-function-definitions

I want you to add star in the same way as FunctionDeclaration.
