### PR TITLE
Add support for destructing assignment in VariableDeclarator

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1648,7 +1648,15 @@
                     })
                 ];
             } else {
-                result = generateIdentifier(stmt.id);
+                if (stmt.id.type === Syntax.ArrayPattern || stmt.id.type === Syntax.ObjectPattern) {
+                    result = generateExpression(stmt.id, {
+                        precedence: Precedence.Assignment,
+                        allowIn: allowIn,
+                        allowCall: true
+                    });
+                } else {
+                    result = generateIdentifier(stmt.id);
+                }
             }
             break;
 

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -1408,6 +1408,63 @@ data = {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 28 }
             }
+        },
+
+        'for (let {\n            a: b,\n            c: d\n        } in obj) {\n}': {
+            generateFrom: {
+                type: 'Program',
+                body: [{
+                    type: 'ForInStatement',
+                    left: {
+                        type: 'VariableDeclaration',
+                        kind: 'let',
+                        declarations: [
+                            {
+                                type: 'VariableDeclarator',
+                                id: {
+                                    type: 'ObjectPattern',
+                                    properties: [
+                                        {
+                                            type: 'Property',
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'a'
+                                            },
+                                            value: {
+                                                type: 'Identifier',
+                                                name: 'b'
+                                            },
+                                            kind: 'init'
+                                        },
+                                        {
+                                            type: 'Property',
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'c'
+                                            },
+                                            value: {
+                                                type: 'Identifier',
+                                                name: 'd'
+                                            },
+                                            kind: 'init'
+                                        }
+                                    ]
+                                },
+                                init: null
+                            }
+                        ]
+                    },
+                    right: {
+                        type: 'Identifier',
+                        name: 'obj'
+                    },
+                    body: {
+                        type: 'BlockStatement',
+                        body: []
+                    },
+                    each: false
+                }]
+            }
         }
     },
 
@@ -1652,6 +1709,47 @@ data = {
             loc: {
                 start: { line: 1, column: 0 },
                 end: { line: 1, column: 17 }
+            }
+        },
+
+        'for (let [\n            a,\n            b\n        ] in obj) {\n}': {
+            generateFrom: {
+                type: 'Program',
+                body: [{
+                    type: 'ForInStatement',
+                    left: {
+                        type: 'VariableDeclaration',
+                        kind: 'let',
+                        declarations: [
+                            {
+                                type: 'VariableDeclarator',
+                                id: {
+                                    type: 'ArrayPattern',
+                                    elements: [
+                                        {
+                                            type: 'Identifier',
+                                            name: 'a'
+                                        },
+                                        {
+                                            type: 'Identifier',
+                                            name: 'b'
+                                        }
+                                    ]
+                                },
+                                init: null
+                            }
+                        ]
+                    },
+                    right: {
+                        type: 'Identifier',
+                        name: 'obj'
+                    },
+                    body: {
+                        type: 'BlockStatement',
+                        body: []
+                    },
+                    each: false
+                }]
             }
         }
     },


### PR DESCRIPTION
There can be Destructing Assignment in VariableDeclarator when looping through object.
`for (let {a: b, c: d} in obj) {}` - `ObjectPattern`
`for (let [a, b] in obj) {}` - `ArrayPattern`

Here's the example on MDN
https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/1.7#Looping_across_objects

`VariableDeclarator` can contain Pattern in its `id` part
https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API#Declarations

Patterns can be of `ArrayPattern` and `ObjectPattern types`
https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API#Patterns
