### PR TITLE
Fix CatchClause order

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1721,6 +1721,13 @@
             } else {
                 stmt.guardedHandlers = stmt.guardedHandlers || [];
 
+                for (i = 0, len = stmt.guardedHandlers.length; i < len; ++i) {
+                    result = join(result, generateStatement(stmt.guardedHandlers[i]));
+                    if (stmt.finalizer || i + 1 !== len) {
+                        result = maybeBlockSuffix(stmt.guardedHandlers[i].body, result);
+                    }
+                }
+
                 // new interface
                 if (stmt.handler) {
                     if (isArray(stmt.handler)) {
@@ -1732,16 +1739,9 @@
                         }
                     } else {
                         result = join(result, generateStatement(stmt.handler));
-                        if (stmt.finalizer || stmt.guardedHandlers.length > 0) {
+                        if (stmt.finalizer) {
                             result = maybeBlockSuffix(stmt.handler.body, result);
                         }
-                    }
-                }
-
-                for (i = 0, len = stmt.guardedHandlers.length; i < len; ++i) {
-                    result = join(result, generateStatement(stmt.guardedHandlers[i]));
-                    if (stmt.finalizer || i + 1 !== len) {
-                        result = maybeBlockSuffix(stmt.guardedHandlers[i].body, result);
                     }
                 }
             }

--- a/test/test.js
+++ b/test/test.js
@@ -12871,6 +12871,80 @@ data = {
             }
         },
 
+        'try {\n} catch (ex if ex instanceof A) {\n} catch (ex if ex instanceof B) {\n} catch (ex) {\n}': {
+            generateFrom: {
+                type: "Program",
+                body: [{
+                    type: "TryStatement",
+                    block: {
+                        type: "BlockStatement",
+                        body: []
+                    },
+                    guardedHandlers: [
+                        {
+                            type: "CatchClause",
+                            param: {
+                                type: "Identifier",
+                                name: "ex"
+                            },
+                            guard: {
+                                type: "BinaryExpression",
+                                operator: "instanceof",
+                                left: {
+                                    type: "Identifier",
+                                    name: "ex"
+                                },
+                                right: {
+                                    type: "Identifier",
+                                    name: "A"
+                                }
+                            },
+                            body: {
+                                type: "BlockStatement",
+                                body: []
+                            }
+                        },
+                        {
+                            type: "CatchClause",
+                            param: {
+                                type: "Identifier",
+                                name: "ex"
+                            },
+                            guard: {
+                                type: "BinaryExpression",
+                                operator: "instanceof",
+                                left: {
+                                    type: "Identifier",
+                                    name: "ex"
+                                },
+                                right: {
+                                    type: "Identifier",
+                                    name: "B"
+                                }
+                            },
+                            body: {
+                                type: "BlockStatement",
+                                body: []
+                            }
+                        }
+                    ],
+                    handler: {
+                        type: "CatchClause",
+                        param: {
+                            type: "Identifier",
+                            name: "ex"
+                        },
+                        guard: null,
+                        body: {
+                            type: "BlockStatement",
+                            body: []
+                        }
+                    },
+                    finalizer: null
+                }]
+            }
+        },
+
         'try { } finally { cleanup(stuff) }': {
             type: 'TryStatement',
             block: {


### PR DESCRIPTION
Unfortunately [this PR](https://github.com/Constellation/escodegen/pull/150) contained an error, because there were no tests in it. This PR fixes the CatchClause order.
