### PR TITLE
Patch to address #157

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -496,15 +496,18 @@
      * either strings or nested arrays
      */
     function flattenToString(arr) {
-        var result = '', i = 0, len = arr.length, elem;
-        for ( ; i < len; i++) {
+        var i, iz, elem, result = '';
+        for (i = 0, iz = arr.length; i < iz; ++i) {
             elem = arr[i];
             result += isArray(elem) ? flattenToString(elem) : elem;
         }
         return result;
     }
 
-    function toSourceNode(generated, node) {
+    /**
+     * convert generated to a SourceNode when source maps are enabled.
+     */
+    function toSourceNodeWhenNeeded(generated, node) {
         if (!sourceMap) {
             // with no source maps, generated is either an
             // array or a string.  if an array, flatten it.
@@ -533,8 +536,8 @@
     }
 
     function join(left, right) {
-        var leftSource = toSourceNode(left).toString(),
-            rightSource = toSourceNode(right).toString(),
+        var leftSource = toSourceNodeWhenNeeded(left).toString(),
+            rightSource = toSourceNodeWhenNeeded(right).toString(),
             leftCharCode = leftSource.charCodeAt(leftSource.length - 1),
             rightCharCode = rightSource.charCodeAt(0);
 
@@ -615,7 +618,7 @@
         }
 
         for (i = 1, len = array.length; i < len; ++i) {
-            sn = toSourceNode(addIndent(array[i].slice(spaces)));
+            sn = toSourceNodeWhenNeeded(addIndent(array[i].slice(spaces)));
             array[i] = sourceMap ? sn.join('') : sn;
         }
 
@@ -651,14 +654,14 @@
                 result.push('\n');
             }
             result.push(generateComment(comment));
-            if (!endsWithLineTerminator(toSourceNode(result).toString())) {
+            if (!endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString())) {
                 result.push('\n');
             }
 
             for (i = 1, len = stmt.leadingComments.length; i < len; ++i) {
                 comment = stmt.leadingComments[i];
                 fragment = [generateComment(comment)];
-                if (!endsWithLineTerminator(toSourceNode(fragment).toString())) {
+                if (!endsWithLineTerminator(toSourceNodeWhenNeeded(fragment).toString())) {
                     fragment.push('\n');
                 }
                 result.push(addIndent(fragment));
@@ -668,8 +671,8 @@
         }
 
         if (stmt.trailingComments) {
-            tailingToStatement = !endsWithLineTerminator(toSourceNode(result).toString());
-            specialBase = stringRepeat(' ', calculateSpaces(toSourceNode([base, result, indent]).toString()));
+            tailingToStatement = !endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString());
+            specialBase = stringRepeat(' ', calculateSpaces(toSourceNodeWhenNeeded([base, result, indent]).toString()));
             for (i = 0, len = stmt.trailingComments.length; i < len; ++i) {
                 comment = stmt.trailingComments[i];
                 if (tailingToStatement) {
@@ -688,7 +691,7 @@
                 } else {
                     result = [result, addIndent(generateComment(comment))];
                 }
-                if (i !== len - 1 && !endsWithLineTerminator(toSourceNode(result).toString())) {
+                if (i !== len - 1 && !endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString())) {
                     result = [result, '\n'];
                 }
             }
@@ -725,7 +728,7 @@
     }
 
     function maybeBlockSuffix(stmt, result) {
-        var ends = endsWithLineTerminator(toSourceNode(result).toString());
+        var ends = endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString());
         if (stmt.type === Syntax.BlockStatement && (!extra.comment || !stmt.leadingComments) && !ends) {
             return [result, space];
         }
@@ -743,11 +746,11 @@
         }
 
         result = parenthesize(result, Precedence.Sequence, option.precedence);
-        return toSourceNode(result, expr);
+        return toSourceNodeWhenNeeded(result, expr);
     }
 
     function generateIdentifier(node) {
-        return toSourceNode(node.name, node);
+        return toSourceNodeWhenNeeded(node.name, node);
     }
 
     function generatePattern(node, options) {
@@ -1025,7 +1028,7 @@
                 }), ']');
             } else {
                 if (expr.object.type === Syntax.Literal && typeof expr.object.value === 'number') {
-                    fragment = toSourceNode(result).toString();
+                    fragment = toSourceNodeWhenNeeded(result).toString();
                     // When the following conditions are all true,
                     //   1. No floating point
                     //   2. Don't have exponents
@@ -1065,7 +1068,7 @@
                 } else {
                     // Prevent inserting spaces between operator and argument if it is unnecessary
                     // like, `!cond`
-                    leftSource = toSourceNode(result).toString();
+                    leftSource = toSourceNodeWhenNeeded(result).toString();
                     leftCharCode = leftSource.charCodeAt(leftSource.length - 1);
                     rightCharCode = fragment.toString().charCodeAt(0);
 
@@ -1172,7 +1175,7 @@
                     }
                 }
             });
-            if (multiline && !endsWithLineTerminator(toSourceNode(result).toString())) {
+            if (multiline && !endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString())) {
                 result.push(newline);
             }
             result.push(multiline ? base : '', ']');
@@ -1249,7 +1252,7 @@
                 // to
                 //   dejavu.Class.declare({method2: function () {
                 //       }});
-                if (!hasLineTerminator(toSourceNode(fragment).toString())) {
+                if (!hasLineTerminator(toSourceNodeWhenNeeded(fragment).toString())) {
                     result = [ '{', space, fragment, space, '}' ];
                     break;
                 }
@@ -1274,7 +1277,7 @@
                 }
             });
 
-            if (!endsWithLineTerminator(toSourceNode(result).toString())) {
+            if (!endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString())) {
                 result.push(newline);
             }
             result.push(base, '}');
@@ -1316,7 +1319,7 @@
                 }
             });
 
-            if (multiline && !endsWithLineTerminator(toSourceNode(result).toString())) {
+            if (multiline && !endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString())) {
                 result.push(newline);
             }
             result.push(multiline ? base : '', '}');
@@ -1463,7 +1466,7 @@
             throw new Error('Unknown expression type: ' + expr.type);
         }
 
-        return toSourceNode(result, expr);
+        return toSourceNodeWhenNeeded(result, expr);
     }
 
     function generateStatement(stmt, option) {
@@ -1502,7 +1505,7 @@
                         directiveContext: functionBody
                     }));
                     result.push(fragment);
-                    if (!endsWithLineTerminator(toSourceNode(fragment).toString())) {
+                    if (!endsWithLineTerminator(toSourceNodeWhenNeeded(fragment).toString())) {
                         result.push(newline);
                     }
                 }
@@ -1602,7 +1605,7 @@
             })];
             // 12.4 '{', 'function' is not allowed in this position.
             // wrap expression with parentheses
-            fragment = toSourceNode(result).toString();
+            fragment = toSourceNodeWhenNeeded(result).toString();
             if (fragment.charAt(0) === '{' ||  // ObjectExpression
                     (fragment.slice(0, 8) === 'function' && '* ('.indexOf(fragment.charAt(8)) >= 0) ||  // function or generator
                     (directive && directiveContext && stmt.expression.type === Syntax.Literal && typeof stmt.expression.value === 'string')) {
@@ -1751,7 +1754,7 @@
                 for (i = 0, len = stmt.cases.length; i < len; ++i) {
                     fragment = addIndent(generateStatement(stmt.cases[i], {semicolonOptional: i === len - 1}));
                     result.push(fragment);
-                    if (!endsWithLineTerminator(toSourceNode(fragment).toString())) {
+                    if (!endsWithLineTerminator(toSourceNodeWhenNeeded(fragment).toString())) {
                         result.push(newline);
                     }
                 }
@@ -1782,14 +1785,14 @@
                     i = 1;
                 }
 
-                if (i !== len && !endsWithLineTerminator(toSourceNode(result).toString())) {
+                if (i !== len && !endsWithLineTerminator(toSourceNodeWhenNeeded(result).toString())) {
                     result.push(newline);
                 }
 
                 for (; i < len; ++i) {
                     fragment = addIndent(generateStatement(stmt.consequent[i], {semicolonOptional: i === len - 1 && semicolon === ''}));
                     result.push(fragment);
-                    if (i + 1 !== len && !endsWithLineTerminator(toSourceNode(fragment).toString())) {
+                    if (i + 1 !== len && !endsWithLineTerminator(toSourceNodeWhenNeeded(fragment).toString())) {
                         result.push(newline);
                     }
                 }
@@ -1907,7 +1910,7 @@
                     })
                 );
                 result.push(fragment);
-                if (i + 1 < len && !endsWithLineTerminator(toSourceNode(fragment).toString())) {
+                if (i + 1 < len && !endsWithLineTerminator(toSourceNodeWhenNeeded(fragment).toString())) {
                     result.push(newline);
                 }
             }
@@ -1978,12 +1981,12 @@
             result = addCommentsToStatement(stmt, result);
         }
 
-        fragment = toSourceNode(result).toString();
+        fragment = toSourceNodeWhenNeeded(result).toString();
         if (stmt.type === Syntax.Program && !safeConcatenation && newline === '' &&  fragment.charAt(fragment.length - 1) === '\n') {
-            result = sourceMap ? toSourceNode(result).replaceRight(/\s+$/, '') : fragment.replace(/\s+$/, '');
+            result = sourceMap ? toSourceNodeWhenNeeded(result).replaceRight(/\s+$/, '') : fragment.replace(/\s+$/, '');
         }
 
-        return toSourceNode(result, stmt);
+        return toSourceNodeWhenNeeded(result, stmt);
     }
 
     function generate(node, options) {


### PR DESCRIPTION
Rather than using SourceNodeMock objects when source maps are
disabled, use raw strings for better performance.
