### PR TITLE
Fixes Constellation/escodegen#174.

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2234,7 +2234,8 @@
         }
 
         if (!sourceMap) {
-            return result.toString();
+            pair = {code: result.toString(), map: null};
+            return options.sourceMapWithCode ? pair : pair.code;
         }
 
 

--- a/test/source-map.js
+++ b/test/source-map.js
@@ -505,4 +505,22 @@ describe('source map test', function () {
         var consumer = new sourcemap.SourceMapConsumer(output.map.toString());
         expect(consumer.sourceContentFor("sum.ls")).to.be.equal(source);
     });
+
+    it('sourceMapWithCode forces output format', function() {
+        var ast = {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "Literal",
+                "value": 1
+            }
+        };
+
+        // sourceMapWithCode should force result format to be object even with sourceMap:false
+        var result = escodegen.generate(ast, {
+            sourceMapWithCode: true
+        });
+
+        expect(result.code).to.be.a('string');
+        expect(result.map).to.be.equal(null);
+    });
 });


### PR DESCRIPTION
Fixes Constellation/escodegen#174 (`sourceMapWithCode` should unambiguously set result format to `{code, map}` pair independently from `sourceMap` option).
