### PR TITLE
Add preserveBlankLines option

### DIFF
--- a/test/preserve-blank-lines.js
+++ b/test/preserve-blank-lines.js
@@ -1,0 +1,76 @@
+/*
+  Copyright (C) 2011-2013 Yusuke Suzuki <utatane.tea@gmail.com>
+  Copyright (C) 2014 Kevin Barabash <kevinb7@gmail.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+var fs = require('fs'),
+    esprima = require('esprima'),
+    escodegen = require('./loader'),
+    chai = require('chai'),
+    expect = chai.expect;
+
+function test(code, expected) {
+    var tree, actual, options, StringObject;
+
+    // alias, so that JSLint does not complain.
+    StringObject = String;
+
+    options = {
+        range: true,
+        tokens: true,
+        comment: true
+    };
+
+    tree = esprima.parse(code, options);
+    tree = escodegen.attachComments(tree, tree.comments, tree.tokens);
+
+    options = {
+        comment: true,
+        sourceCode: code,
+        format: {
+            preserveBlankLines: true
+        }
+    };
+
+    // for UNIX text comment
+    actual = escodegen.generate(tree, options);
+    expect(actual).to.be.equal(expected);
+}
+
+describe('preserve blank lines test', function () {
+    fs.readdirSync(__dirname + '/preserve-blank-lines').sort().forEach(function(file) {
+        var code, expected, p;
+        if (/\.js$/.test(file) && !/expected\.js$/.test(file)) {
+            it(file, function () {
+                p = file.replace(/\.js$/, '.expected.js');
+                code = fs.readFileSync(__dirname + '/preserve-blank-lines/' + file, 'utf-8');
+                expected = fs.readFileSync(__dirname + '/preserve-blank-lines/' + p, 'utf-8');
+                test(code, expected);
+            });
+        }
+    });
+});
+
+/* vim: set sw=4 ts=4 et tw=80 : */

--- a/test/preserve-blank-lines/block-comments.expected.js
+++ b/test/preserve-blank-lines/block-comments.expected.js
@@ -1,0 +1,23 @@
+var x;  /* block comment after code */
+
+var y = 5;
+
+/* block comment in between lines */
+
+var z = 10;
+
+/**
+ *  multiline block comment
+ */
+
+var foo = function () {
+    var a = 0;
+    
+    /* block comment in a function */
+    
+    var b = 1;
+    
+    /**
+     * multiline block comment in a function
+     */
+};

--- a/test/preserve-blank-lines/block-comments.js
+++ b/test/preserve-blank-lines/block-comments.js
@@ -1,0 +1,23 @@
+var x;  /* block comment after code */
+
+var y = 5;
+
+/* block comment in between lines */
+
+var z = 10;
+
+/**
+ *  multiline block comment
+ */
+
+var foo = function () {
+    var a = 0;
+    
+    /* block comment in a function */
+    
+    var b = 1;
+    
+    /**
+     * multiline block comment in a function
+     */
+};

--- a/test/preserve-blank-lines/comments.expected.js
+++ b/test/preserve-blank-lines/comments.expected.js
@@ -1,0 +1,19 @@
+/* single line block comment */
+
+var x;
+
+// single line comment
+
+var y = 5;  // comment after code
+
+var z = 10;
+
+var foo = function () {
+    var a = 0;
+    
+    // single line comment in function
+    
+    var b = 1;  // commdent after code in a function
+    
+    var c = 2;
+};

--- a/test/preserve-blank-lines/comments.js
+++ b/test/preserve-blank-lines/comments.js
@@ -1,0 +1,19 @@
+/* single line block comment */
+
+var x;
+
+// single line comment
+
+var y = 5;  // comment after code
+
+var z = 10;
+
+var foo = function () {
+    var a = 0;
+    
+    // single line comment in function
+    
+    var b = 1;  // commdent after code in a function
+    
+    var c = 2;
+};

--- a/test/preserve-blank-lines/functions.expected.js
+++ b/test/preserve-blank-lines/functions.expected.js
@@ -1,0 +1,19 @@
+var foo = function () {
+    var a;
+};
+
+function bar() {
+    var b;
+}
+
+var empty_foo = function () {
+    
+};
+
+function empty_bar() {
+    // TODO: implement this function
+}
+
+foo();
+
+bar();

--- a/test/preserve-blank-lines/functions.js
+++ b/test/preserve-blank-lines/functions.js
@@ -1,0 +1,19 @@
+var foo = function () {
+    var a;
+};
+
+function bar() {
+    var b;
+}
+
+var empty_foo = function () {
+    
+};
+
+function empty_bar() {
+    // TODO: implement this function
+}
+
+foo();
+
+bar();

--- a/test/preserve-blank-lines/variables.expected.js
+++ b/test/preserve-blank-lines/variables.expected.js
@@ -1,0 +1,5 @@
+var x;
+
+var y = 5;
+
+var z = 10;

--- a/test/preserve-blank-lines/variables.js
+++ b/test/preserve-blank-lines/variables.js
@@ -1,0 +1,5 @@
+var x;
+
+var y = 5;
+
+var z = 10;


### PR DESCRIPTION
I'm using escodegen to reformat user code in the Khan Academy live-editor.  If a student adds spaces between lines to make things more reabable we'd like to maintain that format while fixing the indentation and other issues that might exist.
