### PR TITLE
Updated old URL and standardised the indenting

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; URL=http://constellation.github.com/escodegen/demo/index.html">
+	<meta http-equiv="refresh" content="0; URL=http://estools.github.com/escodegen/demo/index.html">
 </head>
 <body>
 </body>


### PR DESCRIPTION
The old URL was pointing to a page that no longer exists, since the repository was moved to https://github.com/estools/