### PR TITLE
fixes #231: generate strings with fewer escape sequences by default

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -469,7 +469,7 @@
             } else if (esutils.code.isLineTerminator(code) || code === 0x5C  /* \ */) {
                 result += escapeDisallowedCharacter(code);
                 continue;
-            } else if ((json && code < 0x20  /* SP */) || !(json || escapeless || (code >= 0x20  /* SP */ && code <= 0x7E  /* ~ */))) {
+            } else if (!esutils.code.isIdentifierPart(code) && (json && code < 0x20  /* SP */ || !json && !escapeless && (code < 0x20  /* SP */ || code > 0x7E  /* ~ */))) {
                 result += escapeAllowedCharacter(code, str.charCodeAt(i + 1));
                 continue;
             }

--- a/test/options.js
+++ b/test/options.js
@@ -325,7 +325,7 @@ data = [{
             '+\' !"#$%&\\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\';',
         '+\'\\x7F\'': '+\'\\x7F\';',
         '+\'\\x80\'': '+\'\\x80\';',
-        '+\'\\u0100\'': '+\'\\u0100\';',
+        '+\'\\u0100\'': '+\'\u0100\';',
         '+\'hello, world\\n\'': '+\'hello, world\\n\';',
         '+"hello, world\\n"': '+\'hello, world\\n\';'
     }
@@ -362,7 +362,7 @@ data = [{
             '+" !\\"#$%&\'()*+,-.\\/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";',
         '+\'\\x7F\'': '+"\x7F";',
         '+\'\\x80\'': '+"\x80";',
-        '+\'\\u0100\'': '+"\u0100";',
+        '+\'\\u0101\'': '+"\u0101";',
         '+\'hello, world\\n\'': '+"hello, world\\n";',
         '+"hello, world\\n"': '+"hello, world\\n";'
     }
@@ -399,7 +399,7 @@ data = [{
             '+" !\\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";',
         '+\'\\x7F\'': '+"\\x7F";',
         '+\'\\x80\'': '+"\\x80";',
-        '+\'\\u0100\'': '+"\\u0100";',
+        '+\'\\u0102\'': '+"\u0102";',
         '+\'hello, world\\n\'': '+"hello, world\\n";',
         '+"hello, world\\n"': '+"hello, world\\n";'
     }
@@ -436,7 +436,7 @@ data = [{
             '+\' !"#$%&\\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\';',
         '+\'\\x7F\'': '+\'\\x7F\';',
         '+\'\\x80\'': '+\'\\x80\';',
-        '+\'\\u0100\'': '+\'\\u0100\';',
+        '+\'\\u0103\'': '+\'\u0103\';',
         '+\'hello, world\\n\'': '+\'hello, world\\n\';',
         '+"hello, world\\n"': '+\'hello, world\\n\';'
     }
@@ -473,7 +473,7 @@ data = [{
             '+\' !"#$%&\\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\';',
         '+\'\\x7F\'': '+\'\x7F\';',
         '+\'\\x80\'': '+\'\x80\';',
-        '+\'\\u0100\'': '+\'\u0100\';',
+        '+\'\\u0104\'': '+\'\u0104\';',
         '+\'hello, world\\n\'': '+\'hello, world\\n\';',
         '+"hello, world\\n"': '+\'hello, world\\n\';'
     }
@@ -510,7 +510,7 @@ data = [{
             '+\' !"#$%&\\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\';',
         '+\'\\x7F\'': '+\'\\x7F\';',
         '+\'\\x80\'': '+\'\\x80\';',
-        '+\'\\u0100\'': '+\'\\u0100\';',
+        '+\'\\u0105\'': '+\'\\u0105\';',
         '+\'hello, world\\n\'': '+\'hello, world\\n\';',
         '+"hello, world\\n"': '+"hello, world\\n";'
     }


### PR DESCRIPTION
Fixes #231. Many more characters are now represented literally instead of by their unicode escapes by default. /cc @vkz