### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,7 @@
         "gulp-mocha": "^2.0.0",
         "semver": "^4.1.0"
     },
-    "licenses": [
-        {
-            "type": "BSD",
-            "url": "http://github.com/estools/escodegen/raw/master/LICENSE.BSD"
-        }
-    ],
+    "license": "BSD-2-Clause",
     "scripts": {
         "test": "gulp travis",
         "unit-test": "gulp test",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/