### PR TITLE
Expand RestElement to support all patterns

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2063,7 +2063,7 @@
         },
 
         RestElement: function(expr, precedence, flags) {
-            return '...' + generateIdentifier(expr.argument);
+            return '...' + this.generatePattern(expr.argument);
         },
 
         ClassExpression: function (expr, precedence, flags) {

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -1494,6 +1494,47 @@ data = {
                     }
                 ]
             }
+        },
+        '[x, ...[y,z]] = list;': {
+            "type": "Program",
+            "body": [
+                {
+                    "type": "ExpressionStatement",
+                    "expression": {
+                        "type": "AssignmentExpression",
+                        "operator": "=",
+                        "left": {
+                            "type": "ArrayPattern",
+                            "elements": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "x"
+                                },
+                                {
+                                    "type": "RestElement",
+                                    "argument": {
+                                        "type": "ArrayPattern",
+                                        "elements": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "y"
+                                            },
+                                            {
+                                                "type": "Identifier",
+                                                "name": "z"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "right": {
+                            "type": "Identifier",
+                            "name": "list"
+                        }
+                    }
+                }
+            ]
         }
     },
 


### PR DESCRIPTION
This is a followup to #236 that brings RestElement into full spec compliance.