### PR TITLE
fix unhandled undefined pattern literal

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2270,7 +2270,7 @@
                 }
             }
 
-            if (expr.value === null) {
+            if (typeof expr.value === 'undefined' || expr.value === null) {
                 return 'null';
             }
 


### PR DESCRIPTION
RegExp pattern literal may be undefined, leading app crashes in generateRegExp()