### PR TITLE
Fix inline comments edge case with preseveBlankLines

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -739,6 +739,10 @@
                 prefix = sourceCode.substring(extRange[0], range[0]);
                 count = (prefix.match(/\n/g) || []).length;
 
+                if (typeof result !== 'array') {
+                    result = [result];
+                }
+
                 if (count > 0) {
                     result.push(stringRepeat('\n', count));
                     result.push(addIndent(generateComment(comment)));
@@ -2132,12 +2136,14 @@
         },
 
         ObjectExpression: function (expr, precedence, flags) {
-            var multiline, result, fragment, that = this;
+            var multiline, result, fragment, trailingCommentExists, that = this;
 
             if (!expr.properties.length) {
                 return '{}';
             }
-            multiline = expr.properties.length > 1;
+            
+            trailingCommentExists = extra.comment && expr.properties.length === 1 && expr.properties[0].value.trailingComments;
+            multiline = expr.properties.length > 1 || trailingCommentExists;
 
             withIndent(function () {
                 fragment = that.generateExpression(expr.properties[0], Precedence.Sequence, E_TTT);

--- a/test/preserve-blank-lines/trailing-comment-in-object.expected.js
+++ b/test/preserve-blank-lines/trailing-comment-in-object.expected.js
@@ -1,0 +1,3 @@
+var x = {
+    a: 2 // this is a comment
+};

--- a/test/preserve-blank-lines/trailing-comment-in-object.js
+++ b/test/preserve-blank-lines/trailing-comment-in-object.js
@@ -1,0 +1,3 @@
+var x = {
+    a: 2 // this is a comment
+};


### PR DESCRIPTION
This fixes an edge case with preseveBlankLines and objects with only one property.

For instance, an object of the form

```
var x = {
  a: 1 // test
}
```

would resolve to
```
var x = { a:1 //test }
```