### PR TITLE
Fix Import variable binding for esprima 2

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2262,9 +2262,11 @@
         },
 
         ExportSpecifier: function (expr, precedence, flags) {
-            var result = [ (expr.id || expr.local).name ];
-            if (expr.name) {
-                result.push(noEmptySpace() + 'as' + noEmptySpace() + generateIdentifier(expr.name));
+            var exported = (expr.id || expr.imported).name;
+            var result = [ exported ];
+            var id = expr.name || expr.local;
+            if (id && id.name !== exported) {
+                result.push(noEmptySpace() + 'as' + noEmptySpace() + generateIdentifier(id));
             }
             return result;
         },

--- a/test/compare-esprima2/import-with-default.expected.js
+++ b/test/compare-esprima2/import-with-default.expected.js
@@ -2,7 +2,7 @@ import foo from 'foo';
 import foo, * as foo from 'foo';
 import * as foo from 'foo';
 import ok, {
-    foo,
-    test,
+    foo as bar,
+    test as testing,
     logging
 } from 'foo';

--- a/test/compare-esprima2/import-with-default.expected.min.js
+++ b/test/compare-esprima2/import-with-default.expected.min.js
@@ -1,1 +1,1 @@
-import foo from'foo';import foo,*as foo from'foo';import*as foo from'foo';import ok,{foo,test,logging}from'foo'
+import foo from'foo';import foo,*as foo from'foo';import*as foo from'foo';import ok,{foo as bar,test as testing,logging}from'foo'

--- a/test/compare-esprima2/import-with-default.js
+++ b/test/compare-esprima2/import-with-default.js
@@ -2,7 +2,7 @@ import foo from 'foo';
 import foo, * as foo from 'foo';
 import * as foo from 'foo';
 import ok, {
-    foo,
-    test,
+    foo as bar,
+    test as testing,
     logging
 } from 'foo';


### PR DESCRIPTION
eg `import {foo as bar} from "baz";`

> The imported field refers to the name of the export imported from the module. The local field refers to the binding imported into the local module scope. If it is a basic named import, such as in import {foo} from "mod", both imported and local are equivalent Identifier nodes; in this case an Identifier node representing foo. If it is an aliased import, such as in import {foo as bar} from "mod", the imported field is an Identifier node representing foo, and the local field is an Identifier node representing bar.

See: https://github.com/estree/estree/blob/master/es6.md#importspecifier
