### PR TITLE
Update semver to the latest version 5.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "gulp": "^3.8.10",
         "gulp-eslint": "^0.2.0",
         "gulp-mocha": "^2.0.0",
-        "semver": "^4.1.0"
+        "semver": "^5.1.0"
     },
     "license": "BSD-2-Clause",
     "scripts": {


### PR DESCRIPTION
semver < 4.3.2 has a security problem: https://nodesecurity.io/advisories/semver_regular-expression-denial-of-service.