### PR TITLE
Travis CI's Node.js versions: exclude 0.11, add iojs and latest stable v4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-    - "0.11"
-    - "0.12"
-matrix:
-    allow_failures:
-        - node_js: "0.11"
+  - "0.10"
+  - "0.12"
+  - iojs
+  - "4"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "version": "1.7.0",
     "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.12.0"
     },
     "maintainers": [
         {


### PR DESCRIPTION
0.11 was considered unstable and superceded already by 0.12. Since >= 0.12 is what is tested, that is the one which should go in the package manifest.