### PR TITLE
Add support for anonymous class declarations in default exports

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1145,7 +1145,10 @@
 
         ClassDeclaration: function (stmt, flags) {
             var result, fragment;
-            result  = ['class ' + stmt.id.name];
+            result  = ['class'];
+            if (stmt.id) {
+                result = join(result, this.generateExpression(stmt.id, Precedence.Sequence, E_TTT));
+            }
             if (stmt.superClass) {
                 fragment = join('extends', this.generateExpression(stmt.superClass, Precedence.Assignment, E_TTT));
                 result = join(result, fragment);

--- a/test/compare-esprima2/export-default-declaration.expected.js
+++ b/test/compare-esprima2/export-default-declaration.expected.js
@@ -2,3 +2,7 @@ export default function a() {
 }
 export default function () {
 }
+export default class A {
+}
+export default class {
+}

--- a/test/compare-esprima2/export-default-declaration.expected.min.js
+++ b/test/compare-esprima2/export-default-declaration.expected.min.js
@@ -1,1 +1,1 @@
-export default function a(){}export default function (){}
+export default function a(){}export default function (){}export default class A{}export default class{}

--- a/test/compare-esprima2/export-default-declaration.js
+++ b/test/compare-esprima2/export-default-declaration.js
@@ -2,3 +2,5 @@ export default function a () { }
 // export default var i = 20;
 // export default const K = 20;
 export default function () { }
+export default class A { }
+export default class { }


### PR DESCRIPTION
This is required because Esprima uses a ClassDeclaration with a null `id` property when parsing a default export involving an anonymous class.