### PR TITLE
Test with Acorn (not Acorn-6to5) and fix issue with AssignmentPattern

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2205,7 +2205,7 @@
         },
 
         AssignmentPattern: function(expr, precedence, flags) {
-            return this.generateAssignment(expr.left, expr.right, expr.operator, precedence, flags);
+            return this.generateAssignment(expr.left, expr.right, '=', precedence, flags);
         },
 
         ObjectPattern: function (expr, precedence, flags) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "source-map": "~0.2.0"
     },
     "devDependencies": {
-        "acorn-6to5": "^0.11.1-25",
+        "acorn": "^2.7.0",
         "bluebird": "^2.3.11",
         "bower-registry-client": "^0.2.1",
         "chai": "^1.10.0",

--- a/test/compare-acorn-es6.js
+++ b/test/compare-acorn-es6.js
@@ -25,7 +25,7 @@
 'use strict';
 
 var fs = require('fs'),
-    acorn = require('acorn-6to5'),
+    acorn = require('acorn'),
     escodegen = require('./loader'),
     chai = require('chai'),
     expect = chai.expect;
@@ -37,11 +37,9 @@ function test(code, expected) {
     StringObject = String;
 
     options = {
-        range: true,
-        loc: false,
-        tokens: true,
-        raw: false,
-        ecmaVersion: 7
+        ranges: true,
+        locations: false,
+        ecmaVersion: 6
     };
 
     tree = acorn.parse(code, options);
@@ -58,11 +56,9 @@ function testMin(code, expected) {
     StringObject = String;
 
     options = {
-        range: true,
-        loc: false,
-        tokens: true,
-        raw: false,
-        ecmaVersion: 7
+        ranges: true,
+        locations: false,
+        ecmaVersion: 6
     };
 
     tree = acorn.parse(code, options);


### PR DESCRIPTION
Acorn-6to5 is not up-to-date. After switching to Acorn, a test failed, showing that escodegen had been improperly handling AssignmentPattern.