### PR TITLE
Add support for inline comments

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -664,6 +664,31 @@
         return '/*' + comment.value + '*/';
     }
 
+    function addInlineComment(stmt, result) {
+        if (stmt.inlineComments) {
+            for (var i = 0; i < stmt.inlineComments.length; i++) {
+                var comment = stmt.inlineComments[i];
+                // For object, replace '{}' in result with empty array
+                if (stmt.type === Syntax.ObjectExpression) {
+                    if (!isArray(result)) {
+                        result = [];
+                        result.push("{");
+                        result.push("\n");
+                        result.push(generateComment(comment));
+                        result.push("}");
+                    } else {
+                        // Add in index 2: index 0 is '{', index 1 is newline
+                        result.splice(2 + i, 0, generateComment(comment));
+                    }
+                } else if (stmt.type === Syntax.BlockStatement) {
+					// Add in index 2: index 0 is '{', index 1 is newline (see definition of BlockStatement)
+                    result.splice(2 + i, 0, generateComment(comment));
+                }
+            }
+        }
+        return result;
+    }
+
     function addComments(stmt, result) {
         var i, len, comment, save, tailingToStatement, specialBase, fragment,
             extRange, range, prevRange, prefix, infix, suffix, count;
@@ -726,7 +751,12 @@
                 }
             }
 
-            result.push(addIndent(save));
+            // Add inline comments after the leading comments were added
+            result.push(addInlineComment(stmt, save));
+        }
+        else {
+          // Add inline comments
+          result = addInlineComment(stmt, result);
         }
 
         if (stmt.trailingComments) {
@@ -2554,5 +2584,6 @@
     exports.browser = false;
     exports.FORMAT_MINIFY = FORMAT_MINIFY;
     exports.FORMAT_DEFAULTS = FORMAT_DEFAULTS;
+    exports._addInlineComment = addInlineComment
 }());
 /* vim: set sw=4 ts=4 et tw=80 : */


### PR DESCRIPTION
In regard to issue #206 ("Attach comment to an empty object"):

I have an initial modification of attachComments() and addComments() which supports comments in empty object/block.

I've called them inline comments, and they are attached to the node which represents the empty object/block (i.e. ObjectExpression/BlockStatement).