### PR TITLE
fix global escodegen reference in entrypoint.js

### DIFF
--- a/tools/entry-point.js
+++ b/tools/entry-point.js
@@ -25,5 +25,5 @@
 (function () {
     'use strict';
     global.escodegen = require('../escodegen');
-    escodegen.browser = true;
+    global.escodegen.browser = true;
 }());


### PR DESCRIPTION
See https://github.com/estools/escodegen/issues/244.

Attempting to use the release-built `escodegen.browser.js` fails on import because `escodegen` in `entry-point.js` is not defined.

Alternatively, it may be better to eliminate `entry-point.js` entirely, as since it isn't part of the NPM version, it is impossible to run `npm run-script build` unless cloning from source.