### PR TITLE
Bug when generate regexp from objects [not string]

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2326,7 +2326,7 @@
                 return expr.value ? 'true' : 'false';
             }
 
-            return generateRegExp(expr.value);
+            return generateRegExp(expr.raw);
         },
 
         GeneratorExpression: function (expr, precedence, flags) {


### PR DESCRIPTION
When regexp is an object the value is undefined.