### PR TITLE
fix: use regexp raw literal if possible

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2331,6 +2331,9 @@
                 return expr.value ? 'true' : 'false';
             }
 
+            if (expr.regex) {
+              return '/' + expr.regex.pattern + '/' + expr.regex.flags;
+            }
             return generateRegExp(expr.value);
         },
 


### PR DESCRIPTION
to get around not serializable regexp the raw literal value should be used instead of the value

FIX ISSUE #294