### PR TITLE
Adding in support for block labels

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1028,7 +1028,8 @@
     CodeGenerator.Statement = {
 
         BlockStatement: function (stmt, flags) {
-            var range, content, result = ['{', newline], that = this;
+            var open = stmt.label ? stmt.label.name + '{' : '{';
+            var range, content, result = [open, newline], that = this;
 
             withIndent(function () {
                 // handle functions without any code


### PR DESCRIPTION
The block statement supports labeling by identifier, and this is missing from the code generator.  