### PR TITLE
Preserve blank fix

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1710,7 +1710,8 @@
 
                     // handle spaces between lines
                     if (i > 0) {
-                        if (!stmt.body[i - 1].trailingComments && !stmt.body[i].leadingComments) {
+                        if (!stmt.body[i - 1].trailingComments && !stmt.body[i].leadingComments &&
+                          stmt.body[i - 1].range && stmt.body[i].range) {
                             generateBlankLines(stmt.body[i - 1].range[1], stmt.body[i].range[0], result);
                         }
                     }

--- a/escodegen.js
+++ b/escodegen.js
@@ -62,6 +62,7 @@
         sourceMap,
         sourceCode,
         preserveBlankLines,
+        wrapIIFE,
         FORMAT_MINIFY,
         FORMAT_DEFAULTS;
 
@@ -190,7 +191,8 @@
                 parentheses: true,
                 semicolons: true,
                 safeConcatenation: false,
-                preserveBlankLines: false
+                preserveBlankLines: false,
+                wrapIIFE: false
             },
             moz: {
                 comprehensionExpressionStartsWithAssignment: false,
@@ -1872,7 +1874,7 @@
         },
 
         CallExpression: function (expr, precedence, flags) {
-            var result, i, iz;
+            var result, i, iz, isIIFE;
             // F_ALLOW_UNPARATH_NEW becomes false.
             result = [this.generateExpression(expr.callee, Precedence.Call, E_TTF)];
             result.push('(');
@@ -1887,7 +1889,12 @@
             if (!(flags & F_ALLOW_CALL)) {
                 return ['(', result, ')'];
             }
-            return parenthesize(result, Precedence.Call, precedence);
+
+            isIIFE = expr.callee.id === null && expr.callee.params.length === 0;
+
+            return (isIIFE && wrapIIFE) ?
+                parenthesize(result, 0, 1) :
+                parenthesize(result, Precedence.Call, precedence);
         },
 
         NewExpression: function (expr, precedence, flags) {
@@ -2546,6 +2553,7 @@
         sourceMap = options.sourceMap;
         sourceCode = options.sourceCode;
         preserveBlankLines = options.format.preserveBlankLines && sourceCode !== null;
+        wrapIIFE = options.format.wrapIIFE;
         extra = options;
 
         if (sourceMap) {

--- a/escodegen.js
+++ b/escodegen.js
@@ -741,6 +741,10 @@
                 prefix = sourceCode.substring(extRange[0], range[0]);
                 count = (prefix.match(/\n/g) || []).length;
 
+                if (typeof result === 'string') {
+                  result = [result];
+                }
+
                 if (count > 0) {
                     result.push(stringRepeat('\n', count));
                     result.push(addIndent(generateComment(comment)));
@@ -1062,14 +1066,15 @@
                                     result = ['{'];
                                 }
                             }
-                            if (!stmt.body[0].leadingComments) {
+                            if (!stmt.body[0].leadingComments && stmt.body[0].range) {
                                 generateBlankLines(stmt.range[0], stmt.body[0].range[0], result);
                             }
                         }
 
                         // handle spaces between lines
                         if (i > 0) {
-                            if (!stmt.body[i - 1].trailingComments  && !stmt.body[i].leadingComments) {
+                            if (!stmt.body[i - 1].trailingComments  && !stmt.body[i].leadingComments &&
+                              stmt.body[i - 1].range && stmt.body[i].range) {
                                 generateBlankLines(stmt.body[i - 1].range[1], stmt.body[i].range[0], result);
                             }
                         }
@@ -1101,7 +1106,7 @@
                     if (preserveBlankLines) {
                         // handle spaces after the last line
                         if (i === iz - 1) {
-                            if (!stmt.body[i].trailingComments) {
+                            if (!stmt.body[i].trailingComments && stmt.body[i].range) {
                                 generateBlankLines(stmt.body[i].range[1], stmt.range[1], result);
                             }
                         }
@@ -1703,7 +1708,7 @@
                 if (preserveBlankLines) {
                     // handle spaces before the first line
                     if (i === 0) {
-                        if (!stmt.body[0].leadingComments) {
+                        if (!stmt.body[0].leadingComments && stmt.body[i].range) {
                             generateBlankLines(stmt.range[0], stmt.body[i].range[0], result);
                         }
                     }
@@ -1732,7 +1737,7 @@
                 if (preserveBlankLines) {
                     // handle spaces after the last line
                     if (i === iz - 1) {
-                        if (!stmt.body[i].trailingComments) {
+                        if (!stmt.body[i].trailingComments && stmt.body[i].range) {
                             generateBlankLines(stmt.body[i].range[1], stmt.range[1], result);
                         }
                     }


### PR DESCRIPTION
At line 1714, there is a potential bug, if a Program block has a child with no range attached.  This can cause an exception:

```
TypeError: Cannot read property '0' of undefined
    at CodeGenerator.Program (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:1714:93)
    at CodeGenerator.generateStatement (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:2479:33)
    at generateInternal (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:2500:28)
    at Object.generate (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/escodegen/escodegen.js:2569:18)
    at Translator.write (/Volumes/DevPartition/pdev/toolbox/node/m12n/src/translator.js:98:24)
    at DestroyableTransform._transform (/Volumes/DevPartition/pdev/toolbox/node/m12n/src/translator.js:417:23)
    at DestroyableTransform.Transform._read (/Volumes/DevPartition/pdev/toolbox/node/m12n/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:159:10)

```

This fix simply checks for the existence of a range. Made the same fix for BlockStatement.
