### PR TITLE
MetaProperty fields as Identifier

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1943,9 +1943,9 @@
         MetaProperty: function (expr, precedence, flags) {
             var result;
             result = [];
-            result.push(expr.meta);
+            result.push(typeof expr.meta === "string" ? expr.meta : generateIdentifier(expr.meta));
             result.push('.');
-            result.push(expr.property);
+            result.push(typeof expr.property === "string" ? expr.property : generateIdentifier(expr.property));
             return parenthesize(result, Precedence.Member, precedence);
         },
 

--- a/test/harmony-esprima2.js
+++ b/test/harmony-esprima2.js
@@ -39,7 +39,7 @@ var esprima = require('./3rdparty/esprima-2.7.1'),
 
 data = {
     'Harmony MetaProperty': {
-        'class SomeClass { constructor() { if (new.target === SomeClass) { throw new Error(\'Boom\'); }}}': {            
+        'class SomeClass { constructor() { if (new.target === SomeClass) { throw new Error(\'Boom\'); }}}': {
             type: 'Program',
             body: [ {
                 type: "ClassDeclaration",
@@ -73,8 +73,14 @@ data = {
                                                 operator: "===",
                                                 left: {
                                                     type: "MetaProperty",
-                                                    meta: "new",
-                                                    property: "target"
+                                                    meta: {
+                                                        type: "Identifier",
+                                                        name: "new"
+                                                    },
+                                                    property: {
+                                                        type: "Identifier",
+                                                        name: "target"
+                                                    },
                                                 },
                                                 right: {
                                                     type: "Identifier",


### PR DESCRIPTION
According to https://github.com/estree/estree/blob/master/es2015.md#m…etaproperty the `meta` and `property` members are `Identifier` not plain strings.

Keep support for plain strings for backward compatibility.