### PR TITLE
Support async iteration statement `for-await-of` introduced in ES2018

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -951,7 +951,7 @@
     };
 
     CodeGenerator.prototype.generateIterationForStatement = function (operator, stmt, flags) {
-        var result = ['for' + space + '('], that = this;
+        var result = ['for' + space + (stmt.await ? 'await' + space : '') + '('], that = this;
         withIndent(function () {
             if (stmt.left.type === Syntax.VariableDeclaration) {
                 withIndent(function () {

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -6208,6 +6208,78 @@ data = {
                 "async": true
             }
         },
+    },
+
+    'ES2018 for-await-of': {
+        'async function f() {\n    for await (const x of ait) {\n        console.log(x);\n    }\n}': {
+            generateFrom: {
+                "type": "FunctionDeclaration",
+                "id": {
+                    "type": "Identifier",
+                    "name": "f"
+                },
+                "params": [],
+                "body": {
+                    "type": "BlockStatement",
+                    "body": [
+                        {
+                            "type": "ForOfStatement",
+                            "left": {
+                                "type": "VariableDeclaration",
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "id": {
+                                            "type": "Identifier",
+                                            "name": "x"
+                                        },
+                                        "init": null
+                                    }
+                                ],
+                                "kind": "const"
+                            },
+                            "right": {
+                                "type": "Identifier",
+                                "name": "ait"
+                            },
+                            "body": {
+                                "type": "BlockStatement",
+                                "body": [
+                                    {
+                                        "type": "ExpressionStatement",
+                                        "expression": {
+                                            "type": "CallExpression",
+                                            "callee": {
+                                                "type": "MemberExpression",
+                                                "object": {
+                                                    "type": "Identifier",
+                                                    "name": "console"
+                                                },
+                                                "property": {
+                                                    "type": "Identifier",
+                                                    "name": "log"
+                                                },
+                                                "computed": false
+                                            },
+                                            "arguments": [
+                                                {
+                                                    "type": "Identifier",
+                                                    "name": "x"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "await": true
+                        }
+                    ]
+                },
+                "generator": false,
+                "async": true
+            }
+        }
+
     }
 };
 


### PR DESCRIPTION
Generates `for-await-of` statement using `await` property of `ForOfStatement`.

```js
async function f() {
    for await (const x of ait) {
        console.log(x);
    }
}
```

refs: https://tc39.github.io/proposal-async-iteration/
refs: https://github.com/tc39/proposal-async-iteration#the-async-iteration-statement-for-await-of
refs: https://github.com/estree/estree/pull/185