### PR TITLE
Support async generator method introduced in ES2018

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -868,13 +868,15 @@
     }
 
     function generateMethodPrefix(prop) {
-        var func = prop.value;
+        var func = prop.value, prefix = '';
         if (func.async) {
-            return generateAsyncPrefix(func, !prop.computed);
-        } else {
-            // avoid space before method name
-            return generateStarSuffix(func) ? '*' : '';
+            prefix += generateAsyncPrefix(func, !prop.computed);
         }
+        if (func.generator) {
+            // avoid space before method name
+            prefix += generateStarSuffix(func) ? '*' : '';
+        }
+        return prefix;
     }
 
     CodeGenerator.prototype.generatePattern = function (node, precedence, flags) {

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -6280,7 +6280,104 @@ data = {
             }
         }
 
+    },
+
+    'ES2018 async generator method': {
+        'class C {\n    async *readLines(file) {\n        while (!file.EOF) {\n            yield await file.readLine();\n        }\n    }\n}': {
+            generateFrom: {
+                "type": "ClassDeclaration",
+                "id": {
+                    "type": "Identifier",
+                    "name": "C"
+                },
+                "superClass": null,
+                "body": {
+                    "type": "ClassBody",
+                    "body": [
+                        {
+                            "type": "MethodDefinition",
+                            "key": {
+                                "type": "Identifier",
+                                "name": "readLines"
+                            },
+                            "value": {
+                                "type": "FunctionExpression",
+                                "id": null,
+                                "params": [
+                                    {
+                                        "type": "Identifier",
+                                        "name": "file"
+                                    }
+                                ],
+                                "body": {
+                                    "type": "BlockStatement",
+                                    "body": [
+                                        {
+                                            "type": "WhileStatement",
+                                            "test": {
+                                                "type": "UnaryExpression",
+                                                "operator": "!",
+                                                "prefix": true,
+                                                "argument": {
+                                                    "type": "MemberExpression",
+                                                    "object": {
+                                                        "type": "Identifier",
+                                                        "name": "file"
+                                                    },
+                                                    "property": {
+                                                        "type": "Identifier",
+                                                        "name": "EOF"
+                                                    },
+                                                    "computed": false
+                                                }
+                                            },
+                                            "body": {
+                                                "type": "BlockStatement",
+                                                "body": [
+                                                    {
+                                                        "type": "ExpressionStatement",
+                                                        "expression": {
+                                                            "type": "YieldExpression",
+                                                            "argument": {
+                                                                "type": "AwaitExpression",
+                                                                "argument": {
+                                                                    "type": "CallExpression",
+                                                                    "callee": {
+                                                                        "type": "MemberExpression",
+                                                                        "object": {
+                                                                            "type": "Identifier",
+                                                                            "name": "file"
+                                                                        },
+                                                                        "property": {
+                                                                            "type": "Identifier",
+                                                                            "name": "readLine"
+                                                                        },
+                                                                        "computed": false
+                                                                    },
+                                                                    "arguments": []
+                                                                }
+                                                            },
+                                                            "delegate": false
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "generator": true,
+                                "async": true
+                            },
+                            "kind": "method",
+                            "computed": false,
+                            "static": false
+                        }
+                    ]
+                }
+            }
+        }
     }
+
 };
 
 function updateDeeply(target, override) {


### PR DESCRIPTION
Support async generator method introduced in ES2018

```js
class C {
    async *readLines(file) {
        while (!file.EOF) {
            yield await file.readLine();
        }
    }
}
```

escodegen supports async generator functions, but not methods.

refs: https://tc39.github.io/proposal-async-iteration/
refs: https://tc39.github.io/proposal-async-iteration/#prod-AsyncGeneratorMethod
