### PR TITLE
Fix null object conversion error in AST node

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2308,7 +2308,7 @@
                 }
             }
 
-            if (expr.value === null) {
+            if (expr.raw === 'null' && expr.value===undefined) {
                 return 'null';
             }
 


### PR DESCRIPTION
In escodegen.js, converting a null object into source code in AST will generate an error on toString(). This is because the original judgment considers that the null object node has a "value" key value.
Previous code：escodegen.js-----Lines 2310 to 2313：
if (expr.value === null) {return 'null'; }
I think I can change the above code to:
if (expr.raw === 'null' && expr.value===undefined) {return 'null'; }
This way it can be converted from the ast tree to the original code when it encounters a null object normally.
testcase code(Nodejs environment):
var esprima=require("esprima");
var escodegen=require("escodegen");
var ast=esprima.parse("var a=null;");
var code=escodegen.generate(ast);