### PR TITLE
add support for optional catch binding

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -1176,15 +1176,19 @@
             withIndent(function () {
                 var guard;
 
-                result = [
-                    'catch' + space + '(',
-                    that.generateExpression(stmt.param, Precedence.Sequence, E_TTT),
-                    ')'
-                ];
+                if (!stmt.param) {
+                    result = ['catch'];
+                } else {
+                    result = [
+                        'catch' + space + '(',
+                        that.generateExpression(stmt.param, Precedence.Sequence, E_TTT),
+                        ')'
+                    ];
 
-                if (stmt.guard) {
-                    guard = that.generateExpression(stmt.guard, Precedence.Sequence, E_TTT);
-                    result.splice(2, 0, ' if ', guard);
+                    if (stmt.guard) {
+                        guard = that.generateExpression(stmt.guard, Precedence.Sequence, E_TTT);
+                        result.splice(2, 0, ' if ', guard);
+                    }
                 }
             });
             result.push(this.maybeBlock(stmt.body, S_TFFF));

--- a/test/test.js
+++ b/test/test.js
@@ -13320,6 +13320,44 @@ data = {
                     expression: false
                 }]
             }
+        },
+
+        'try { } catch { }': {
+            type: 'TryStatement',
+            block: {
+                type: 'BlockStatement',
+                body: [],
+                range: [4, 7],
+                loc: {
+                    start: { line: 1, column: 4 },
+                    end: { line: 1, column: 7 }
+                }
+            },
+            handlers: [{
+                type: 'CatchClause',
+                param: null,
+                guard: null,
+                body: {
+                    type: 'BlockStatement',
+                    body: [],
+                    range: [14, 17],
+                    loc: {
+                        start: { line: 1, column: 14 },
+                        end: { line: 1, column: 17 }
+                    }
+                },
+                range: [8, 17],
+                loc: {
+                    start: { line: 1, column: 8 },
+                    end: { line: 1, column: 17 }
+                }
+            }],
+            finalizer: null,
+            range: [0, 17],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 17 }
+            }
         }
 
     },


### PR DESCRIPTION
Fixes #382.

Tests rely on [esprima 1953](https://github.com/jquery/esprima/issues/1953) or they will throw early:
```
  1) general test try statement:
     AssertionError: expected [Function] to not throw an error but 'Error: Line 1: Unexpected token {' was thrown
      at testIdentity (test/test.js:14946:23)
      at runTest (test/test.js:14974:9)
      at test/test.js:14983:17
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (test/test.js:14981:41)
```
This PR can hibernate until there's progress on esprima's end, and until esprima dependency version bumps to 4.x+.