### PR TITLE
Change the precedence of await so it's the same as other unary expressions

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -82,7 +82,6 @@
     Precedence = {
         Sequence: 0,
         Yield: 1,
-        Await: 1,
         Assignment: 1,
         Conditional: 2,
         ArrowFunction: 2,
@@ -96,6 +95,7 @@
         BitwiseSHIFT: 10,
         Additive: 11,
         Multiplicative: 12,
+        Await: 13,
         Unary: 13,
         Postfix: 14,
         Call: 15,

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -5927,6 +5927,46 @@ data = {
             }
         },
 
+        'async function test() {\n    await (foo ? bar : quux);\n}': {
+            generateFrom: {
+                "type": "FunctionDeclaration",
+                "id": {
+                    "type": "Identifier",
+                    "name": "test"
+                },
+                "params": [],
+                "body": {
+                    "type": "BlockStatement",
+                    "body": [
+                        {
+                            "type": "ExpressionStatement",
+                            "expression": {
+                                "type": "AwaitExpression",
+                                "argument": {
+                                    "type": "ConditionalExpression",
+                                    "test": {
+                                        "type": "Identifier",
+                                        "name": "foo"
+                                    },
+                                    "consequent": {
+                                        "type": "Identifier",
+                                        "name": "bar"
+                                    },
+                                    "alternate": {
+                                        "type": "Identifier",
+                                        "name": "quux"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                "generator": false,
+                "expression": false,
+                "async": true
+            }   
+        },
+
         'f(async function (promise) {\n    await promise;\n});': {
             generateFrom: {
                 "type": "ExpressionStatement",


### PR DESCRIPTION
Fixes #384

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence