### PR TITLE
support 'regex' property when 'value' is null

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2308,6 +2308,10 @@
                 }
             }
 
+            if (expr.regex) {
+              return '/' + expr.regex.pattern + '/' + expr.regex.flags;
+            }
+
             if (expr.value === null) {
                 return 'null';
             }
@@ -2324,9 +2328,6 @@
                 return expr.value ? 'true' : 'false';
             }
 
-            if (expr.regex) {
-              return '/' + expr.regex.pattern + '/' + expr.regex.flags;
-            }
             return generateRegExp(expr.value);
         },
 

--- a/test/test.js
+++ b/test/test.js
@@ -4429,6 +4429,32 @@ data = {
                 value: '/[P QR]/\\g',
                 range: [8, 18]
             }]
+        },
+
+        'var x = /foo/i;': {
+            generateFrom: {
+                type: 'Program',
+                body: [{
+                    type: 'VariableDeclaration',
+                    kind: 'var',
+                    declarations: [{
+                        type: 'VariableDeclarator',
+                        id: {
+                            type: 'Identifier',
+                            name: 'x',
+                        },
+                        init: {
+                            type: 'Literal',
+                            value: null,
+                            raw: '/foo/i',
+                            regex: {
+                                pattern: 'foo',
+                                flags: 'i'
+                            }
+                        },
+                    }]
+                }],
+            }
         }
 
     },


### PR DESCRIPTION
Hello there! Thank you very much for the work that's gone into this library :)

I come with a PR to fix an issue which came up while using escodegen to test Terser's mozilla AST generation.

[According to the spec](https://github.com/estree/estree/blob/master/es5.md#regexpliteral) it's possible to set a `RegExpLiteral`'s value to `null` such that the RegExp is fully defined in the `regex` property. We need to do this always in Terser since we print the estree serialized JSON to standard output, which is a medium that doesn't allow us to use actual regular expressions.

To fix this, I just placed the logic that tests whether the Literal is a RegExpLiteral (IE checking for the regex property) above the other checks, which allows it to circumvent an early return of `'null'` in this case.

Thanks! :D