### PR TITLE
Update esprima to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dependencies": {
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "optionator": "^0.8.1"
     },
     "optionalDependencies": {


### PR DESCRIPTION
This allows users to use a newer version of esprima in their root node_modules and make sure that escodegen uses that version, rather than its bundled 3.x version.

Closes #366
Relates to #391