### PR TITLE
Support trees with immediate .start and .end (without .range)

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -61,7 +61,6 @@
         sourceMap,
         sourceCode,
         preserveBlankLines,
-        noRange,
         FORMAT_MINIFY,
         FORMAT_DEFAULTS;
 
@@ -82,11 +81,10 @@
 
     // Get range either by directly accessing .start + .end or accessing .range
     function getRange(node) {
-        if (!noRange) {
-            return node.range;
-        } else {
+        if (!("range" in node)) {
             return [node.start, node.end];
         }
+        return node.range;
     }
 
     Precedence = {
@@ -211,8 +209,7 @@
             directive: false,
             raw: true,
             verbatim: null,
-            sourceCode: null,
-            noRange: false
+            sourceCode: null
         };
     }
 
@@ -2558,7 +2555,6 @@
         sourceMap = options.sourceMap;
         sourceCode = options.sourceCode;
         preserveBlankLines = options.format.preserveBlankLines && sourceCode !== null;
-        noRange = options.noRange;
         extra = options;
 
         if (sourceMap) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,5 +79,5 @@ gulp.task('lint', function () {
         .pipe(eslint.failOnError());
 });
 
-gulp.task('travis', [ 'lint', 'test' ]);
-gulp.task('default', [ 'travis' ]);
+gulp.task('travis', gulp.parallel('lint', 'test'));
+gulp.task('default', gulp.parallel('travis'));

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
         "bower-registry-client": "^1.0.0",
         "chai": "^3.5.0",
         "commonjs-everywhere": "^0.9.7",
-        "gulp": "^3.8.10",
-        "gulp-eslint": "^3.0.1",
-        "gulp-mocha": "^3.0.1",
+        "gulp": "^4.0.1",
+        "gulp-eslint": "^6.0.0",
+        "gulp-mocha": "^7.0.2",
         "semver": "^5.1.0"
     },
     "license": "BSD-2-Clause",

--- a/test/range.js
+++ b/test/range.js
@@ -1,0 +1,86 @@
+/*
+ Copyright (C) 2019 Guy Lewin <guy@lewin.co.il>
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+var fs = require('fs'),
+    esprima = require('esprima'),
+    escodegen = require('./loader'),
+    chai = require('chai'),
+    expect = chai.expect;
+
+function test(tree) {
+    var tree, actual;
+    var code = "{\n    }";
+    var options = {
+        preserveBlankLines: true,
+        sourceCode: code,
+        format: {
+            preserveBlankLines: true
+        }
+    };
+
+    actual = escodegen.generate(tree, options);
+    expect(actual).to.be.equal(code);
+}
+
+describe('test building trees with and without range', function () {
+    it("with range - Esprima built", function () {
+        // Parsed by Esprima
+        test({
+            "type": "Program",
+            "body": [{
+                "type": "BlockStatement",
+                "body": [],
+                "range": [
+                    0,
+                    7
+                ]
+            }],
+            "sourceType": "module",
+            "range": [
+                0,
+                7
+            ]
+        });
+    });
+
+    it("without range - Acorn built", function () {
+        // Parsed by Acorn
+        test({
+            "type": "Program",
+            "start": 0,
+            "end": 7,
+            "body": [{
+                "type": "BlockStatement",
+                "start": 0,
+                "end": 7,
+                "body": []
+            }],
+            "sourceType": "module"
+        });
+    });
+});
+
+/* vim: set sw=4 ts=4 et tw=80 : */


### PR DESCRIPTION
Acorn and Meriyah are generating trees that have .start and .end properties without wrapping .range array.
I added support for parsing such trees + tests to check our range usage