### PR TITLE
fixed multiline decision for object patterns with rest elements

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2215,7 +2215,10 @@
             multiline = false;
             if (expr.properties.length === 1) {
                 property = expr.properties[0];
-                if (property.value.type !== Syntax.Identifier) {
+                if (
+                    property.type === Syntax.Property
+                    && property.value.type !== Syntax.Identifier
+                ) {
                     multiline = true;
                 }
             } else {

--- a/escodegen.js
+++ b/escodegen.js
@@ -2224,7 +2224,10 @@
             } else {
                 for (i = 0, iz = expr.properties.length; i < iz; ++i) {
                     property = expr.properties[i];
-                    if (!property.shorthand) {
+                    if (
+                        property.type === Syntax.Property
+                        && !property.shorthand
+                    ) {
                         multiline = true;
                         break;
                     }

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -2548,6 +2548,24 @@ data = {
         }
     },
 
+    'Harmony object pattern single rest-element property': {
+        '{...a}': {
+            generateFrom: {
+                type: 'ObjectPattern',
+                start: 8,
+                properties: [
+                    {
+                        type: 'RestElement',
+                        'argument': {
+                            type: 'Identifier',
+                            name: 'a'
+                        }
+                    }
+                ]
+            }
+        }
+    },
+
     'Harmony method property': {
         'var obj = { test() { } }': {
             type: 'Program',

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -2549,19 +2549,37 @@ data = {
     },
 
     'Harmony object pattern single rest-element property': {
-        '{...a}': {
+        'const {...foo} = {};': {
             generateFrom: {
-                type: 'ObjectPattern',
-                start: 8,
-                properties: [
+                type: 'Program',
+                body: [
                     {
-                        type: 'RestElement',
-                        'argument': {
-                            type: 'Identifier',
-                            name: 'a'
-                        }
+                        type: 'VariableDeclaration',
+                        declarations: [
+                            {
+                                type: 'VariableDeclarator',
+                                id: {
+                                    type: 'ObjectPattern',
+                                    properties: [
+                                        {
+                                            type: 'RestElement',
+                                            'argument': {
+                                                type: 'Identifier',
+                                                name: 'foo'
+                                            }
+                                        }
+                                    ]
+                                },
+                                init: {
+                                    type: 'ObjectExpression',
+                                    properties: []
+                                }
+                            }
+                        ],
+                        kind: 'const'
                     }
-                ]
+                ],
+                sourceType: "script"
             }
         }
     },

--- a/test/harmony.js
+++ b/test/harmony.js
@@ -2548,7 +2548,7 @@ data = {
         }
     },
 
-    'Harmony object pattern single rest-element property': {
+    'Harmony object pattern, singleline, 1 property: RestElement': {
         'const {...foo} = {};': {
             generateFrom: {
                 type: 'Program',
@@ -2568,6 +2568,227 @@ data = {
                                                 name: 'foo'
                                             }
                                         }
+                                    ]
+                                },
+                                init: {
+                                    type: 'ObjectExpression',
+                                    properties: []
+                                }
+                            }
+                        ],
+                        kind: 'const'
+                    }
+                ],
+                sourceType: "script"
+            }
+        }
+    },
+
+    'Harmony object pattern, singleline, 2 properties: Property, Property': {
+        'const {foo, bar} = {};': {
+            generateFrom: {
+                type: 'Program',
+                body: [
+                    {
+                        type: 'VariableDeclaration',
+                        declarations: [
+                            {
+                                type: 'VariableDeclarator',
+                                id: {
+                                    type: 'ObjectPattern',
+                                    properties: [
+                                        {
+                                            type: 'Property',
+                                            method: false,
+                                            shorthand: true,
+                                            computed: false,
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'foo'
+                                            },
+                                            kind: 'init',
+                                            value: {
+                                                type: 'Identifier',
+                                                name: 'foo'
+                                            }
+                                        },
+                                        {
+                                            type: 'Property',
+                                            method: false,
+                                            shorthand: true,
+                                            computed: false,
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'bar'
+                                            },
+                                            kind: 'init',
+                                            value: {
+                                                type: 'Identifier',
+                                                name: 'bar'
+                                            }
+                                        },
+                                    ]
+                                },
+                                init: {
+                                    type: 'ObjectExpression',
+                                    properties: []
+                                }
+                            }
+                        ],
+                        kind: 'const'
+                    }
+                ],
+                sourceType: "script"
+            }
+        }
+    },
+
+    'Harmony object pattern, singleline, 2 properties: Property, RestElement': {
+        'const {foo, ...bar} = {};': {
+            generateFrom: {
+                type: 'Program',
+                body: [
+                    {
+                        type: 'VariableDeclaration',
+                        declarations: [
+                            {
+                                type: 'VariableDeclarator',
+                                id: {
+                                    type: 'ObjectPattern',
+                                    properties: [
+                                        {
+                                            type: 'Property',
+                                            method: false,
+                                            shorthand: true,
+                                            computed: false,
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'foo'
+                                            },
+                                            kind: 'init',
+                                            value: {
+                                                type: 'Identifier',
+                                                name: 'foo'
+                                            }
+                                        },
+                                        {
+                                            type: 'RestElement',
+                                            'argument': {
+                                                type: 'Identifier',
+                                                name: 'bar'
+                                            }
+                                        }
+                                    ]
+                                },
+                                init: {
+                                    type: 'ObjectExpression',
+                                    properties: []
+                                }
+                            }
+                        ],
+                        kind: 'const'
+                    }
+                ],
+                sourceType: "script"
+            }
+        }
+    },
+
+    'Harmony object pattern, multiline, 1 property: Property': {
+        'const {\n    foo = 1\n} = {};': {
+            generateFrom: {
+                type: 'Program',
+                body: [
+                    {
+                        type: 'VariableDeclaration',
+                        declarations: [
+                            {
+                                type: 'VariableDeclarator',
+                                id: {
+                                    type: 'ObjectPattern',
+                                    properties: [
+                                        {
+                                            type: 'Property',
+                                            method: false,
+                                            shorthand: true,
+                                            computed: false,
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'foo'
+                                            },
+                                            kind: 'init',
+                                            value: {
+                                                type: 'AssignmentPattern',
+                                                left: {
+                                                    type: 'Identifier',
+                                                    name: 'foo'
+                                                },
+                                                right: {
+                                                    type: 'Literal',
+                                                    value: 1,
+                                                    raw: '1'
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                init: {
+                                    type: 'ObjectExpression',
+                                    properties: []
+                                }
+                            }
+                        ],
+                        kind: 'const'
+                    }
+                ],
+                sourceType: "script"
+            }
+        }
+    },
+
+    'Harmony object pattern, multiline, 2 properties: Property, Property': {
+        'const {\n    foo: bar,\n    baz\n} = {};': {
+            generateFrom: {
+                type: 'Program',
+                body: [
+                    {
+                        type: 'VariableDeclaration',
+                        declarations: [
+                            {
+                                type: 'VariableDeclarator',
+                                id: {
+                                    type: 'ObjectPattern',
+                                    properties: [
+                                        {
+                                            type: 'Property',
+                                            method: false,
+                                            shorthand: false,
+                                            computed: false,
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'foo'
+                                            },
+                                            kind: 'init',
+                                            value: {
+                                                type: 'Identifier',
+                                                name: 'bar'
+                                            }
+                                        },
+                                        {
+                                            type: 'Property',
+                                            method: false,
+                                            shorthand: true,
+                                            computed: false,
+                                            key: {
+                                                type: 'Identifier',
+                                                name: 'baz'
+                                            },
+                                            kind: 'init',
+                                            value: {
+                                                type: 'Identifier',
+                                                name: 'baz'
+                                            }
+                                        },
                                     ]
                                 },
                                 init: {


### PR DESCRIPTION
Fixed error during code generation for object pattern single rest-element property
```
/node_modules/escodegen/escodegen.js:2226
                if (property.value.type !== Syntax.Identifier) {
                                   ^
TypeError: Cannot read property 'type' of undefined
```