### PR TITLE
fixed precedence of sequence expression in computed property name

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -983,13 +983,7 @@
             result.push('[');
         }
 
-        result.push(this.generateExpression(
-            expr,
-            expr.type === Syntax.SequenceExpression
-                ? Precedence.Primary
-                : Precedence.Sequence,
-            E_TTT
-        ));
+        result.push(this.generateExpression(expr, Precedence.Assignment, E_TTT));
 
         if (computed) {
             result.push(']');

--- a/escodegen.js
+++ b/escodegen.js
@@ -983,7 +983,13 @@
             result.push('[');
         }
 
-        result.push(this.generateExpression(expr, Precedence.Sequence, E_TTT));
+        result.push(this.generateExpression(
+            expr,
+            expr.type === Syntax.SequenceExpression
+                ? Precedence.Primary
+                : Precedence.Sequence,
+            E_TTT
+        ));
 
         if (computed) {
             result.push(']');

--- a/test/compare-acorn-es6/class-declaration.expected.js
+++ b/test/compare-acorn-es6/class-declaration.expected.js
@@ -2,6 +2,10 @@ class ComputedKey {
     [n1 + n2]() {
     }
 }
+class ComputedKeyWithParenthesis {
+    [(n1 + n2) * n3]() {
+    }
+}
 class SequenceExpressionAsKey {
     [(n1, n2)]() {
     }

--- a/test/compare-acorn-es6/class-declaration.expected.js
+++ b/test/compare-acorn-es6/class-declaration.expected.js
@@ -3,7 +3,7 @@ class ComputedKey {
     }
 }
 class ComputedKeyWithParenthesis {
-    [(n1 + n2) * n3]() {
+    [n1 = (n2 + n3) * n4]() {
     }
 }
 class SequenceExpressionAsKey {

--- a/test/compare-acorn-es6/class-declaration.expected.js
+++ b/test/compare-acorn-es6/class-declaration.expected.js
@@ -2,8 +2,8 @@ class ComputedKey {
     [n1 + n2]() {
     }
 }
-class ComputedKeyWithParenthesis {
-    [n1 = (n2 + n3) * n4]() {
+class AssignmentExpressionAsKey {
+    [n1 = n2]() {
     }
 }
 class SequenceExpressionAsKey {

--- a/test/compare-acorn-es6/class-declaration.expected.js
+++ b/test/compare-acorn-es6/class-declaration.expected.js
@@ -1,0 +1,8 @@
+class ComputedKey {
+    [n1 + n2]() {
+    }
+}
+class SequenceExpressionAsKey {
+    [(n1, n2)]() {
+    }
+}

--- a/test/compare-acorn-es6/class-declaration.expected.min.js
+++ b/test/compare-acorn-es6/class-declaration.expected.min.js
@@ -1,0 +1,1 @@
+class ComputedKey{[n1+n2](){}}class SequenceExpressionAsKey{[(n1,n2)](){}}

--- a/test/compare-acorn-es6/class-declaration.expected.min.js
+++ b/test/compare-acorn-es6/class-declaration.expected.min.js
@@ -1,1 +1,1 @@
-class ComputedKey{[n1+n2](){}}class ComputedKeyWithParenthesis{[(n1+n2)*n3](){}}class SequenceExpressionAsKey{[(n1,n2)](){}}
+class ComputedKey{[n1+n2](){}}class ComputedKeyWithParenthesis{[n1=(n2+n3)*n4](){}}class SequenceExpressionAsKey{[(n1,n2)](){}}

--- a/test/compare-acorn-es6/class-declaration.expected.min.js
+++ b/test/compare-acorn-es6/class-declaration.expected.min.js
@@ -1,1 +1,1 @@
-class ComputedKey{[n1+n2](){}}class SequenceExpressionAsKey{[(n1,n2)](){}}
+class ComputedKey{[n1+n2](){}}class ComputedKeyWithParenthesis{[(n1+n2)*n3](){}}class SequenceExpressionAsKey{[(n1,n2)](){}}

--- a/test/compare-acorn-es6/class-declaration.expected.min.js
+++ b/test/compare-acorn-es6/class-declaration.expected.min.js
@@ -1,1 +1,1 @@
-class ComputedKey{[n1+n2](){}}class ComputedKeyWithParenthesis{[n1=(n2+n3)*n4](){}}class SequenceExpressionAsKey{[(n1,n2)](){}}
+class ComputedKey{[n1+n2](){}}class AssignmentExpressionAsKey{[n1=n2](){}}class SequenceExpressionAsKey{[(n1,n2)](){}}

--- a/test/compare-acorn-es6/class-declaration.js
+++ b/test/compare-acorn-es6/class-declaration.js
@@ -1,0 +1,6 @@
+class ComputedKey {
+    [n1 + n2]() {}
+}
+class SequenceExpressionAsKey {
+    [(n1, n2)]() {}
+}

--- a/test/compare-acorn-es6/class-declaration.js
+++ b/test/compare-acorn-es6/class-declaration.js
@@ -2,7 +2,7 @@ class ComputedKey {
     [n1 + n2]() {}
 }
 class ComputedKeyWithParenthesis {
-    [(n1 + n2) * n3]() {}
+    [n1 = (n2 + n3) * n4]() {}
 }
 class SequenceExpressionAsKey {
     [(n1, n2)]() {}

--- a/test/compare-acorn-es6/class-declaration.js
+++ b/test/compare-acorn-es6/class-declaration.js
@@ -1,6 +1,9 @@
 class ComputedKey {
     [n1 + n2]() {}
 }
+class ComputedKeyWithParenthesis {
+    [(n1 + n2) * n3]() {}
+}
 class SequenceExpressionAsKey {
     [(n1, n2)]() {}
 }

--- a/test/compare-acorn-es6/class-declaration.js
+++ b/test/compare-acorn-es6/class-declaration.js
@@ -1,8 +1,8 @@
 class ComputedKey {
     [n1 + n2]() {}
 }
-class ComputedKeyWithParenthesis {
-    [n1 = (n2 + n3) * n4]() {}
+class AssignmentExpressionAsKey {
+    [n1 = n2]() {}
 }
 class SequenceExpressionAsKey {
     [(n1, n2)]() {}


### PR DESCRIPTION
Fixes https://github.com/javascript-obfuscator/javascript-obfuscator/issues/638
@michaelficarra this is a high priority bug for my package. Please check this.
