### PR TITLE
drop support for node <6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     ],
     "version": "1.14.3",
     "engines": {
-        "node": ">=4.0"
+        "node": ">=6.0"
     },
     "maintainers": [
         {


### PR DESCRIPTION
Update to nodeJS@6. This is an intermediate update because the goal is to update to the nodeJS@10

