### PR TITLE
Add support Class field declarations

### DIFF
--- a/escodegen.js
+++ b/escodegen.js
@@ -2161,6 +2161,26 @@
             return join(result, fragment);
         },
 
+        FieldDefinition: function(expr, precedence, flags) {
+            let result;
+            if (expr.static) {
+                result = [`static${space}`];
+            }
+            else {
+                result = [];
+            }
+            const fragment = [
+                this.generatePropertyKey(expr.key, expr.computed),
+                `${space}=${space}`,
+                this.generateExpression(expr.value, Precedence.Assignment, E_TTT)
+            ];
+            return join(result, fragment);
+        },
+
+        PrivateName: function(expr, precedence, flags) {
+            return toSourceNodeWhenNeeded(`#${expr.name}`, expr);
+        },
+
         Property: function (expr, precedence, flags) {
             if (expr.kind === 'get' || expr.kind === 'set') {
                 return [

--- a/test/compare-acorn-es2019/class-field-declarations.js
+++ b/test/compare-acorn-es2019/class-field-declarations.js
@@ -1,0 +1,9 @@
+class FieldDeclarations{
+    a = 1
+    b = function () {}
+}
+class PrivateFields{
+    #a = 1
+    #b = function () {}
+}
+


### PR DESCRIPTION
This is required because Acorn uses acorn-class-fields.