### PR TITLE
Use source-map-js instead of source-map

### DIFF
--- a/benchmark/old.js
+++ b/benchmark/old.js
@@ -2636,7 +2636,7 @@
             if (!exports.browser) {
                 // We assume environment is node.js
                 // And prevent from including source-map by browserify
-                SourceNode = require('source-map').SourceNode;
+                SourceNode = require('source-map-js').SourceNode;
             } else {
                 SourceNode = global.sourceMap.SourceNode;
             }

--- a/escodegen.js
+++ b/escodegen.js
@@ -2609,7 +2609,7 @@
             if (!exports.browser) {
                 // We assume environment is node.js
                 // And prevent from including source-map by browserify
-                SourceNode = require('source-map').SourceNode;
+                SourceNode = require('source-map-js').SourceNode;
             } else {
                 SourceNode = global.sourceMap.SourceNode;
             }

--- a/package.json
+++ b/package.json
@@ -32,10 +32,8 @@
     "dependencies": {
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "esprima": "^4.0.1"
-    },
-    "optionalDependencies": {
-        "source-map": "~0.6.1"
+        "esprima": "^4.0.1",
+        "source-map-js": "^1.0.0"
     },
     "devDependencies": {
         "acorn": "^8.0.4",

--- a/test/source-map.js
+++ b/test/source-map.js
@@ -27,7 +27,7 @@
 
 var esprima = require('./3rdparty/esprima-1.0.0-dev'),
     escodegen = require('./loader'),
-    sourcemap = require('source-map'),
+    sourcemap = require('source-map-js'),
     chai = require('chai'),
     expect = chai.expect;
 


### PR DESCRIPTION
Hi,

There is a fork of source-map@0.6 which is 4x times faster and still sync and written in JS only and compatible with Node 6+

More info about fork here: https://github.com/7rulnik/source-map-js#difference-between-original-source-map

This should improve the performance of escodegen without breaking backwards compatibility